### PR TITLE
Release 0.1.3

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,9 @@ PAGES = [
     ],
 	"Uncertain datasets" => [
         "uncertain_datasets/uncertain_datasets_overview.md",
+        "uncertain_datasets/uncertain_index_dataset.md",
         "uncertain_datasets/uncertain_value_dataset.md",
+        "uncertain_datasets/uncertain_dataset.md",
         "uncertain_datasets/uncertain_indexvalue_dataset.md"
 	],
     "Uncertain statistics" => [
@@ -41,6 +43,7 @@ PAGES = [
         "sampling_constraints/constrain_uncertain_values.md"
     ],
     "Resampling" => [
+        "resampling/resampling_overview.md",
         "resampling/resampling_uncertain_values.md",
         "resampling/resampling_uncertain_datasets.md",
         "resampling/resampling_uncertain_indexvalue_datasets.md"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -38,7 +38,7 @@ markdown_extensions:
   - pymdownx.tilde
   - toc:
       permalink: true
-      baselevel: 1
+      baselevel: 2
       separator: "_"
 
 docs_dir: 'build'
@@ -46,22 +46,27 @@ docs_dir: 'build'
 pages:
   - Overview: index.md
   - Uncertain values:
-    - Quickstart: uncertain_values/uncertainvalues_overview.md
-    - Examples: uncertain_values/uncertainvalues_examples.md
-    - Kernel density estimates (KDE): uncertain_values/uncertainvalues_kde.md
-    - Theoretical distributions: uncertain_values/uncertainvalues_theoreticaldistributions.md
-    - Fit theoretical distributions: uncertain_values/uncertainvalues_fitted.md
+    - Overview: uncertain_values/uncertainvalues_overview.md
+    - Extended examples: uncertain_values/uncertainvalues_examples.md
+    - Representations:
+      - Kernel density estimates (KDE): uncertain_values/uncertainvalues_kde.md
+      - Theoretical distributions with known parameters: uncertain_values/uncertainvalues_theoreticaldistributions.md
+      - Theoretical distributions with fitted parameters: uncertain_values/uncertainvalues_fitted.md
   - Uncertain datasets:
-      - Overview, simple example with resampling : uncertain_datasets/uncertain_datasets_overview.md
-      - Uncertain value datasets: uncertain_datasets/uncertain_value_dataset.md
-      - Uncertain index-value datasets: uncertain_datasets/uncertain_indexvalue_dataset.md
-  - Sampling constraints:
-    - List of constraints: sampling_constraints/available_constraints.md
-    - Constraining uncertain values: sampling_constraints/constrain_uncertain_values.md
+      - Overview: uncertain_datasets/uncertain_datasets_overview.md
+      - Generic uncertain dataset: uncertain_datasets/uncertain_dataset.md
+      - Uncertain index dataset: uncertain_datasets/uncertain_index_dataset.md 
+      - Uncertain value dataset: uncertain_datasets/uncertain_value_dataset.md
+      - Uncertain index-value dataset: uncertain_datasets/uncertain_indexvalue_dataset.md
   - Resampling:
-    - Resampling uncertain values: resampling/resampling_uncertain_values.md
-    - Resampling uncertain value datasets: resampling/resampling_uncertain_datasets.md
-    - Resampling uncertain index-value datasets: resampling/resampling_uncertain_indexvalue_datasets.md
+    - Overview: resampling/resampling_overview.md
+    - Constraints:
+        - Constraining uncertain values: sampling_constraints/constrain_uncertain_values.md
+        - List of constraints: sampling_constraints/available_constraints.md
+    - Resampling methods:
+        - Resampling uncertain values: resampling/resampling_uncertain_values.md
+        - Resampling uncertain value datasets: resampling/resampling_uncertain_datasets.md
+        - Resampling uncertain index-value datasets: resampling/resampling_uncertain_indexvalue_datasets.md
   - Mathematics: 
       - Elementary operations: mathematics/elementary_operations.md
       - Trigonometric functions: mathematics/trig_functions.md

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,7 +1,26 @@
+## UncertainData.jl v0.1.3
+
+- Allow both the `indices` and `values` fields of `UncertainIndexValueDataset` to be any 
+    subtype of `AbstractUncertainValueDataset`. This way, you don't **have** to use an 
+    index dataset type for the indices if not necessary.
+- Improved documentation for `UncertainIndexDataset`, `UncertainValueDataset`, 
+    `UncertainDataset` and `UncertainIndexValueDataset` types and added an 
+    [overview page](uncertain_datasets/uncertain_datasets_overview.md) in the documentation 
+    to explain the difference between these types.
+- Added an [overview](resampling/resampling_overview.md) section for the resampling 
+    documentation.
+- Cleaned and improved [documentation for uncertain values](uncertainvalues_overview.md). 
+- Added separate [documentation for the uncertain index dataset type](uncertain_datasets/uncertain_index_dataset.md).
+- Added separate [documentation for the uncertain value dataset type](uncertain_datasets/uncertain_value_dataset.md).
+- Improved [documentation for the generic uncertain dataset type](uncertain_datasets/uncertain_dataset.md) 
+- Merged documentation for sampling constraints and resampling.
+- Added missing documentation for the `sinc`, `sincos`, `sinpi`, `cosc` and `cospi` trig 
+    functions.
 
 ## UncertainData.jl v0.1.2
 
-- Support elementary mathematical operations (`+`, `-`, `*` and `/`) between arbitrary 
+- Support [elementary mathematical operations](mathematics/elementary_operations.md) 
+    (`+`, `-`, `*` and `/`) between arbitrary 
     uncertain values of different types. Also works with the combination of scalars and 
     uncertain values. Because elementary operations should work on arbitrary uncertain 
     values, a resampling approach is used to perform the mathematical operations. This 
@@ -14,7 +33,7 @@
     future, elementary operations might be improved for certain combinations of uncertain
     values where exact expressions for error propagation are now, for example using the 
     machinery in `Measurements.jl` for normally distributed values.
-- Support for trigonometric functions added (`sin`, `sind`, `sinh`, `cos`,
+- Support for [trigonometric functions] (mathematics/trig_functions.md) added (`sin`, `sind`, `sinh`, `cos`,
     `cosd`, `cosh`, `tan`, `tand`, `tanh`, `csc`, `cscd`, `csch`, `csc`, `cscd`, `csch`, 
     `sec`, `secd`, `sech`, `cot`, `cotd`, `coth`, `sincos`, `sinc`, `sinpi`, `cosc`, 
     `cospi`). Inverses are also defined (`asin`, `asind`, `asinh`, `acos`,
@@ -31,9 +50,10 @@
 - Bugfix: due to `StatsBase.std` not being defined for `FittedDistribution` instances, 
     uncertain values represented by `UncertainScalarTheoreticalFit` instances were not 
     compatible with the `TruncateStd` sampling constraint. Now fixed!
-- Improved documentation for resampling for `UncertainIndexValueDataset`s. Now shows 
-    the documentation for the main methods, as well as examples of how to use different sampling constraints for each individual index and data value.
-- Improved documentation for resampling for `UncertainDataset`s. Now shows 
+- Improved resampling documentation for `UncertainIndexValueDataset`s. Now shows 
+    the documentation for the main methods, as well as examples of how to use different 
+    sampling constraints for each individual index and data value.
+- Improved resampling documentation for `UncertainDataset`s. Now shows 
     the documentation for the main methods.
 - Added missing `resample(uv::AbstractUncertainValue, constraint::TruncateRange, n::Int)` 
     method.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,17 +6,19 @@ uncertain datasets more rigorously. It makes workflows involving uncertain data 
 different types and from different sources significantly easier. 
 
 The package allows handling of uncertain values of several different types:
-- theoretical distributions with known parameters
-- theoretical distributions with parameters estimated from experimental data
-- more complex distributions determined by kernel density estimates of experimental data. 
+- [theoretical distributions with known parameters](uncertain_values/uncertainvalues_theoreticaldistributions.md)
+- [theoretical distributions with parameters estimated from experimental data](uncertain_values/uncertainvalues_fitted.md)
+- [more complex distributions determined by kernel density estimates of experimental data](uncertain_values/uncertainvalues_kde.md)
 
 A related package is [Measurements.jl](https://github.com/JuliaPhysics/Measurements.jl),
 which propagates errors exactly and handles correlated uncertainties. However, 
 Measurements.jl accepts only normally distributed values. This package serves a slightly 
-different purpose: it was born to provide an easy way of handling uncertainties of any type,
-using a resampling approach to obtain statistics when needed. The goal is to give the 
-user a consistent and easy way to define uncertain datasets, plot them and reason about them 
-by resampling techniques, possibly subject to sampling constraints.
+different purpose: it was born to provide an easy way of handling uncertainties of **any** 
+type, using a [resampling](resampling/resampling_overview.md) approach to obtain 
+[statistics](uncertain_statistics/core_stats/core_statistics.md)
+when needed, and providing a rich set of 
+[sampling constraints](sampling_constraints/available_constraints.md) that makes it easy 
+for the user to reason about and plot their uncertain data under different assumptions.
 
 ## Package philosophy
 
@@ -25,25 +27,28 @@ dealt with in a systematic manner. The core concept of the package is that uncer
 should live in the probability domain, not as single value representations of the data 
 (e.g. the mean).
 
-In this package, uncertain data values are thus stored as probability distributions. 
+In this package, uncertain data values are thus 
+[stored as probability distributions](uncertain_values/uncertainvalues_overview.md). 
 Only when performing a computation or plotting, the uncertain values are realized by 
 resampling the probability distributions furnishing them. 
 
-Individual uncertain observations may be collected in `UncertainDatasets`, which can be 
+Individual uncertain observations may be collected in 
+[UncertainDatasets](uncertain_datasets/uncertain_datasets_overview.md), which can be 
 sampled according to user-provided sampling constraints. Likewise, indices (e.g. time, 
 depth or any other index) of observations can also be represented as probability 
-distributions and may also sampled using constraints. This may be useful when you, for 
-example, want to draw realizations of your dataset while enforcing strictly increasing age 
-models.
+distributions and may also sampled using constraints. 
+
+The [UncertainIndexValueDataset](uncertain_datasets/uncertain_indexvalue_dataset.md) type 
+allows you to work with datasets where both the indices and data values are uncertain.
+This may be useful when you, for example, want to draw realizations of your dataset while 
+simultaneously enforcing strictly increasing age models.
 
 ## Mathematical operations 
 
 Several [elementary mathematical operations](mathematics/elementary_operations.md) and 
 [trigonometric functions](mathematics/trig_functions.md) are supported 
-for uncertain values. Computations are done using a resampling approach, where the user 
-may choose to use the default number of realizations (`n = 10000`) or tune the number of 
-samples.
-
+for uncertain values. Computations are done using a 
+[resampling approach](resampling/resampling_overview).
 
 ## Statistics on uncertain datasets
 

--- a/docs/src/resampling/resampling_overview.md
+++ b/docs/src/resampling/resampling_overview.md
@@ -1,0 +1,19 @@
+
+
+Because uncertain values are represented by 
+[some kind of probability distribution](../uncertain_values/uncertainvalues_overview.md),
+we may trivially resample them by drawing values from their furnishing distributions.
+
+
+If needed, you may choose to 
+[constrain](../sampling_constraints/constrain_uncertain_values.md) an uncertain value 
+before resampling, using one of the available 
+[sampling constraints](../sampling_constraints/available_constraints.md).
+
+
+The `resample` function is used to resample uncertain values. For detailed instructions
+on how to sample uncertain values and datasets of uncertain values, see the following pages:
+
+- [Resampling uncertain values](resampling_uncertain_values.md)
+- [Resampling uncertain value datasets](resampling_uncertain_datasets.md)
+- [Resampling uncertain index-value datasets](resampling_uncertain_indexvalue_datasets.md)

--- a/docs/src/uncertain_datasets/uncertain_dataset.md
+++ b/docs/src/uncertain_datasets/uncertain_dataset.md
@@ -1,0 +1,103 @@
+`UncertainDataset`s is a generic uncertain dataset type that has no explicit index 
+associated with its uncertain values. 
+
+It inherits all the behaviour of `AbstractUncertainValueDataset`, but may lack some 
+functionality that an [UncertainValueDataset](uncertain_value_dataset.md) has. 
+
+If you don't care about distinguishing between 
+indices and data values, constructing instances of this data type requires five less key 
+presses than [UncertainValueDataset](uncertain_value_dataset.md).
+
+
+## Documentation 
+
+```@docs
+UncertainDataset
+```
+
+## Examples
+
+### Example 1: constructing an `UncertainDataset` from uncertain values
+Let's create a random walk and pretend it represents fluctuations in the mean
+of an observed dataset. Assume that each data point is normally distributed,
+and that the $i$-th observation has standard deviation $\sigma_i \in [0.3, 0.5]$.
+
+Representing these data as an `UncertainDataset` is done as follows:
+
+```julia 
+using UncertainData, Plots
+
+# Create a random walk of 55 steps
+n = 55
+rw = cumsum(rand(Normal(), n))
+
+# Represent each value of the random walk as an uncertain value and
+# collect them in an UncertainDataset
+dist = Uniform(0.3, 0.5)
+uncertainvals = [UncertainValue(Normal, rw[i], rand(dist)) for i = 1:n]
+D = UncertainDataset(uncertainvals)
+```
+
+By default, plotting the dataset will plot the median values (only for scatter plots) along with the 33rd to 67th
+percentile range error bars. 
+
+```
+plot(D)
+```
+
+![](uncertain_value_dataset_plot_defaulterrorbars.svg)
+
+You can customize the error bars by explicitly providing the quantiles:
+
+```
+plot(D, [0.05, 0.95])
+```
+
+![](uncertain_value_dataset_plot_customerrorbars.svg)
+
+
+## Example 2: mixing different types of uncertain values
+Mixing different types of uncertain values also works. Let's create a dataset
+of uncertain values constructed in different ways.
+
+
+```julia
+using UncertainData, Distributions, Plots
+
+# Theoretical distributions
+o1 = UncertainValue(Normal, 0, 0.5)
+o2 = UncertainValue(Normal, 2, 0.3)
+o3 = UncertainValue(Uniform, 0, 4)
+
+# Theoretical distributions fitted to data
+o4 = UncertainValue(Uniform, rand(Uniform(), 100))
+o5 = UncertainValue(Gamma, rand(Gamma(2, 3), 5000))
+
+# Kernel density estimated distributions for some more complex data.
+M1 = MixtureModel([Normal(-5, 0.5), Gamma(2, 5), Normal(12, 0.2)])
+M2 = MixtureModel([Normal(-2, 0.1), Normal(1, 0.2)])
+o6 = UncertainValue(rand(M1, 1000))
+o7 = UncertainValue(rand(M2, 1000))
+
+D = UncertainDataset([o1, o2, o3, o4, o5, o6, o7])
+```
+
+Now, plot the uncertain dataset.
+
+```julia
+
+using Plots
+# Initialise the plot
+p = plot(legend = false, xlabel = "time step", ylabel = "value")
+
+# Plot the mean of the dataset
+plot!([median(D[i]) for i = 1:length(D)], label = "mean", lc = :blue, lw = 3)
+
+for i = 1:200
+    plot!(p, resample(D), lw = 0.4, lα = 0.1, lc = :black)
+end
+
+p
+```
+
+![](uncertaindatasets_differentuncertainvalues.svg)

--- a/docs/src/uncertain_datasets/uncertain_datasets_overview.md
+++ b/docs/src/uncertain_datasets/uncertain_datasets_overview.md
@@ -1,99 +1,23 @@
 If dealing with several uncertain values, it may be useful to represent them
-as an `UncertainDataset`. This way, one may trivially, for example, compute
+as an uncertain dataset. This way, one may trivially, for example, compute
 statistics for a dataset consisting of samples with different types of
 uncertainties.
 
+## Uncertain index datasets and data value datasets
 
-## Example
-Let's create a random walk and pretend it represents fluctuations in the mean
-of an observed dataset. Assume that each data point is normally distributed,
-and that the $i$-th observation has standard deviation $\sigma_i \in [0.3, 0.5]$.
+There are three main types of uncertain datasets: 
 
-Representing these data as an `UncertainDataset` is done as follows:
-
-```julia
-using UncertainData, Distributions, Plots
-
-# Create a random walk of 55 steps
-n = 55
-rw = cumsum(rand(Normal(), n))
-
-# Represent each value of the random walk as an uncertain value and
-# collect them in an UncertainDataset
-dist = Uniform(0.3, 0.5)
-uncertainvals = [UncertainValue(Normal, rw[i], rand(dist)) for i = 1:n]
-D = UncertainDataset(uncertainvals)
-```
+- [UncertainIndexDataset](uncertain_index_dataset.md)s contain uncertain indices.
+- [UncertainValueDataset](uncertain_value_dataset.md)s contain uncertain data values. 
+- [UncertainIndexValueDataset](uncertain_indexvalue_dataset.md)s represent datasets for 
+    which both the indices and the data values are uncertain. It uses
+    `UncertainIndexDataset`s to represent the indices and `UncertainValueDataset`s
+    to represent the data values.
 
 
-We may then resample the dataset by calling `resample(D)`. This will
-[resample each uncertain value](../resampling/resampling_uncertain_values.md)
-in the dataset. Alternatively, `resample(D, n)` resamples `n` times and returns
-a `n`-element vector of resampled realizations.
+## Generic dataset type
+There's also a generic uncertain dataset type for when you don't care about distinguishing 
+between indices and data values: 
 
-Let's resample the uncertain dataset 100 times and plot the realisations.
+- [UncertainDataset](uncertain_dataset.md) contains uncertain indices.
 
-```julia
-using Plots
-
-# Initialise plot
-p = plot(legend = false, xlabel = "time step", ylabel = "value")
-
-# Plot the mean of the dataset
-plot!(mean.(D), label = "mean", lc = :blue, lw = 3)
-
-# Resample the dataset 100 times, add a line to the plot at each iteration
-for i = 1:100
-    plot!(p, resample(D), lw = 0.4, lα = 0.2, lc = :black)
-end
-p
-```
-
-![](uncertaindatasets_exampleplot.svg)
-
-
-## Example 2: mixing different types of uncertain values
-Mixing different types of uncertain values also works. Let's create a dataset
-of uncertain values constructed in different ways.
-
-
-```julia
-using UncertainData, Distributions, Plots
-
-# Theoretical distributions
-o1 = UncertainValue(Normal, 0, 0.5)
-o2 = UncertainValue(Normal, 2, 0.3)
-o3 = UncertainValue(Uniform, 0, 4)
-
-# Theoretical distributions fitted to data
-o4 = UncertainValue(Uniform, rand(Uniform(), 100))
-o5 = UncertainValue(Gamma, rand(Gamma(2, 3), 5000))
-
-# Kernel density estimated distributions for some more complex data.
-M1 = MixtureModel([Normal(-5, 0.5), Gamma(2, 5), Normal(12, 0.2)])
-M2 = MixtureModel([Normal(-2, 0.1), Normal(1, 0.2)])
-o6 = UncertainValue(rand(M1, 1000))
-o7 = UncertainValue(rand(M2, 1000))
-
-D = UncertainDataset([o1, o2, o3, o4, o5, o6, o7])
-```
-
-Now, plot the uncertain dataset.
-
-```julia
-
-using Plots
-# Initialise the plot
-p = plot(legend = false, xlabel = "time step", ylabel = "value")
-
-# Plot the mean of the dataset
-plot!([median(D[i]) for i = 1:length(D)], label = "mean", lc = :blue, lw = 3)
-
-for i = 1:200
-    plot!(p, resample(D), lw = 0.4, lα = 0.1, lc = :black)
-end
-
-p
-```
-
-![](uncertaindatasets_differentuncertainvalues.svg)

--- a/docs/src/uncertain_datasets/uncertain_index_dataset.md
+++ b/docs/src/uncertain_datasets/uncertain_index_dataset.md
@@ -1,0 +1,66 @@
+`UncertainIndexDataset`s is an uncertain dataset type that represents the indices 
+corresponding to an [UncertainValueDataset](uncertain_value_dataset.md).
+
+It is meant to be used for the `indices` field in
+[UncertainIndexValueDataset](uncertain_indexvalue_dataset.md)s instances.
+
+## Documentation
+
+```@docs 
+UncertainIndexDataset
+```
+
+## Examples 
+
+### Example 1: increasing index uncertainty through time
+
+#### Defining the indices
+Say we had a dataset of 20 values for which the uncertainties are normally distributed 
+with increasing standard deviation through time.
+
+```julia 
+time_inds = 1:13
+uvals = [UncertainValue(Normal, ind, rand(Uniform()) + (ind / 6)) for ind in time_inds]
+inds = UncertainIndexDataset(uvals)
+```
+
+Let's plot the 33rd to 67th percentile range for the indices: 
+
+```plot
+plot(inds, [0.33, 0.67])
+```
+
+![](uncertain_indexvalue_dataset_indices.svg)
+
+#### Defining the data
+
+Let's define some uncertain values that are associated with the indices. 
+
+```julia 
+u1 = UncertainValue(Gamma, rand(Gamma(), 500))
+u2 = UncertainValue(rand(MixtureModel([Normal(1, 0.3), Normal(0.1, 0.1)]), 500))
+uvals3 = [UncertainValue(Normal, rand(), rand()) for i = 1:11]
+
+measurements = [u1; u2; uvals3]
+datavals = UncertainValueDataset(measurements)
+```
+
+![](uncertain_indexvalue_dataset_vals.svg)
+
+
+#### Combinining the indices and values 
+
+Now, we combine the indices and the corresponding data. 
+
+```julia 
+d = UncertainIndexDataset(inds, datavals)
+```
+
+Plot the dataset with error bars in both directions, using the 20th to 80th percentile 
+range for the indices and the 33rd to 67th percentile range for the data values. 
+
+```
+plot(d, [0.2, 0.8], [0.33, 0.67])
+```
+
+![](uncertain_indexvalue_dataset_indices_and_vals.svg)

--- a/docs/src/uncertain_datasets/uncertain_indexvalue_dataset.md
+++ b/docs/src/uncertain_datasets/uncertain_indexvalue_dataset.md
@@ -1,6 +1,15 @@
-`UncertainIndexValueDataset`s have uncertainties associated with both the index (e.g. time, depth, etc) and the value itself.
+`UncertainIndexValueDataset`s have uncertainties associated with both the 
+indices (e.g. time, depth, etc) and the values of the data points.
 
-Here's an example of how to create an uncertain index-value dataset.
+
+```@docs 
+UncertainIndexValueDataset
+```
+
+## Example
+
+Here's an example of how to create an uncertain index-value dataset. Let's start by 
+defining the uncertain data values and collecting them in an `UncertainValueDataset`. 
 
 ```julia 
 using UncertainData, Plots 
@@ -11,22 +20,30 @@ r3 = UncertainValue(Uniform, rand(10000))
 r4 = UncertainValue(Normal, -0.1, 0.5)
 r5 = UncertainValue(Gamma, 0.4, 0.8)
 
+u_values = [r1; r2; r3; r4; r5]
+udata = UncertainDataset(u_values);
+```
+
+The values were measures at some time indices by an inaccurate clock, so that the times 
+of measuring are normally distributed values with fluctuating standard deviations.
+
+```julia 
 u_timeindices = [UncertainValue(Normal, i, rand(Uniform(0, 1))) 
     for i = 1:length(udata)]
-
-u_values = [r1; r2; r3; r4; r5]
-
-# A separate UncertainDataset for the data indices and for the data values
 uindices = UncertainDataset(u_timeindices);
-udata = UncertainDataset(u_values);
+```
 
-# Collect them in an uncertain index-value dataset
+Now, combine the uncertain time indices and measurements into an 
+`UncertainIndexValueDataset`.
+
+```julia
 x = UncertainIndexValueDataset(uindices, udata)
 ```
 
-By default, plotting the dataset plots the median value of the index and the measurement (only for scatter plots), 
-along with the 33rd to 67th percentile range error bars in both directions. You can stick 
-to the defaults by calling `plot(udata::UncertainIndexValueDataset)`.
+The built-in plot recipes make it easy to visualize the dataset. 
+By default, plotting the dataset plots the median value of the index and the measurement 
+(only for scatter plots), along with the 33rd to 67th percentile range error bars in both 
+directions. 
 
 ```julia 
 plot(x)
@@ -34,8 +51,9 @@ plot(x)
 
 ![](uncertain_indexvalue_dataset_plot_defaulterrorbars.svg)
 
-Tune the error bars by calling 
-`plot(udata::UncertainIndexValueDataset, idx_quantiles::Vector{Float64}, val_quantiles::Vector{Float64})`, explicitly specifying the quantiles in each direction, like so:
+You can also tune the error bars by calling 
+`plot(udata::UncertainIndexValueDataset, idx_quantiles, val_quantiles)`, explicitly 
+specifying the quantiles in each direction, like so:
 
 ```julia 
 plot(x, [0.05, 0.95], [0.05, 0.95])

--- a/docs/src/uncertain_datasets/uncertain_indexvalue_dataset_indices.svg
+++ b/docs/src/uncertain_datasets/uncertain_indexvalue_dataset_indices.svg
@@ -1,0 +1,750 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Created with matplotlib (https://matplotlib.org/) -->
+<svg height="288pt" version="1.1" viewBox="0 0 432 288" width="432pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <style type="text/css">
+*{stroke-linecap:butt;stroke-linejoin:round;}
+  </style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 288 
+L 432 288 
+L 432 0 
+L 0 0 
+z
+" style="fill:#ffffff;"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 37.424646 261.105354 
+L 429.165354 261.105354 
+L 429.165354 2.834646 
+L 37.424646 2.834646 
+z
+" style="fill:#ffffff;"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path clip-path="url(#p9b784bab91)" d="M 94.707485 261.105354 
+L 94.707485 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path d="M 0 0 
+L 0 -3.5 
+" id="m081e1c8d34" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="94.707485" xlink:href="#m081e1c8d34" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 2.5 -->
+      <defs>
+       <path d="M 19.1875 8.296875 
+L 53.609375 8.296875 
+L 53.609375 0 
+L 7.328125 0 
+L 7.328125 8.296875 
+Q 12.9375 14.109375 22.625 23.890625 
+Q 32.328125 33.6875 34.8125 36.53125 
+Q 39.546875 41.84375 41.421875 45.53125 
+Q 43.3125 49.21875 43.3125 52.78125 
+Q 43.3125 58.59375 39.234375 62.25 
+Q 35.15625 65.921875 28.609375 65.921875 
+Q 23.96875 65.921875 18.8125 64.3125 
+Q 13.671875 62.703125 7.8125 59.421875 
+L 7.8125 69.390625 
+Q 13.765625 71.78125 18.9375 73 
+Q 24.125 74.21875 28.421875 74.21875 
+Q 39.75 74.21875 46.484375 68.546875 
+Q 53.21875 62.890625 53.21875 53.421875 
+Q 53.21875 48.921875 51.53125 44.890625 
+Q 49.859375 40.875 45.40625 35.40625 
+Q 44.1875 33.984375 37.640625 27.21875 
+Q 31.109375 20.453125 19.1875 8.296875 
+z
+" id="DejaVuSans-50"/>
+       <path d="M 10.6875 12.40625 
+L 21 12.40625 
+L 21 0 
+L 10.6875 0 
+z
+" id="DejaVuSans-46"/>
+       <path d="M 10.796875 72.90625 
+L 49.515625 72.90625 
+L 49.515625 64.59375 
+L 19.828125 64.59375 
+L 19.828125 46.734375 
+Q 21.96875 47.46875 24.109375 47.828125 
+Q 26.265625 48.1875 28.421875 48.1875 
+Q 40.625 48.1875 47.75 41.5 
+Q 54.890625 34.8125 54.890625 23.390625 
+Q 54.890625 11.625 47.5625 5.09375 
+Q 40.234375 -1.421875 26.90625 -1.421875 
+Q 22.3125 -1.421875 17.546875 -0.640625 
+Q 12.796875 0.140625 7.71875 1.703125 
+L 7.71875 11.625 
+Q 12.109375 9.234375 16.796875 8.0625 
+Q 21.484375 6.890625 26.703125 6.890625 
+Q 35.15625 6.890625 40.078125 11.328125 
+Q 45.015625 15.765625 45.015625 23.390625 
+Q 45.015625 31 40.078125 35.4375 
+Q 35.15625 39.890625 26.703125 39.890625 
+Q 22.75 39.890625 18.8125 39.015625 
+Q 14.890625 38.140625 10.796875 36.28125 
+z
+" id="DejaVuSans-53"/>
+      </defs>
+      <g transform="translate(88.346235 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path clip-path="url(#p9b784bab91)" d="M 171.700549 261.105354 
+L 171.700549 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="171.700549" xlink:href="#m081e1c8d34" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 5.0 -->
+      <defs>
+       <path d="M 31.78125 66.40625 
+Q 24.171875 66.40625 20.328125 58.90625 
+Q 16.5 51.421875 16.5 36.375 
+Q 16.5 21.390625 20.328125 13.890625 
+Q 24.171875 6.390625 31.78125 6.390625 
+Q 39.453125 6.390625 43.28125 13.890625 
+Q 47.125 21.390625 47.125 36.375 
+Q 47.125 51.421875 43.28125 58.90625 
+Q 39.453125 66.40625 31.78125 66.40625 
+z
+M 31.78125 74.21875 
+Q 44.046875 74.21875 50.515625 64.515625 
+Q 56.984375 54.828125 56.984375 36.375 
+Q 56.984375 17.96875 50.515625 8.265625 
+Q 44.046875 -1.421875 31.78125 -1.421875 
+Q 19.53125 -1.421875 13.0625 8.265625 
+Q 6.59375 17.96875 6.59375 36.375 
+Q 6.59375 54.828125 13.0625 64.515625 
+Q 19.53125 74.21875 31.78125 74.21875 
+z
+" id="DejaVuSans-48"/>
+      </defs>
+      <g transform="translate(165.339299 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-53"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path clip-path="url(#p9b784bab91)" d="M 248.693613 261.105354 
+L 248.693613 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="248.693613" xlink:href="#m081e1c8d34" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 7.5 -->
+      <defs>
+       <path d="M 8.203125 72.90625 
+L 55.078125 72.90625 
+L 55.078125 68.703125 
+L 28.609375 0 
+L 18.3125 0 
+L 43.21875 64.59375 
+L 8.203125 64.59375 
+z
+" id="DejaVuSans-55"/>
+      </defs>
+      <g transform="translate(242.332363 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-55"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path clip-path="url(#p9b784bab91)" d="M 325.686677 261.105354 
+L 325.686677 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="325.686677" xlink:href="#m081e1c8d34" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 10.0 -->
+      <defs>
+       <path d="M 12.40625 8.296875 
+L 28.515625 8.296875 
+L 28.515625 63.921875 
+L 10.984375 60.40625 
+L 10.984375 69.390625 
+L 28.421875 72.90625 
+L 38.28125 72.90625 
+L 38.28125 8.296875 
+L 54.390625 8.296875 
+L 54.390625 0 
+L 12.40625 0 
+z
+" id="DejaVuSans-49"/>
+      </defs>
+      <g transform="translate(316.780427 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path clip-path="url(#p9b784bab91)" d="M 402.67974 261.105354 
+L 402.67974 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="402.67974" xlink:href="#m081e1c8d34" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 12.5 -->
+      <g transform="translate(393.77349 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-50"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- Index -->
+     <defs>
+      <path d="M 9.8125 72.90625 
+L 19.671875 72.90625 
+L 19.671875 0 
+L 9.8125 0 
+z
+" id="DejaVuSans-73"/>
+      <path d="M 54.890625 33.015625 
+L 54.890625 0 
+L 45.90625 0 
+L 45.90625 32.71875 
+Q 45.90625 40.484375 42.875 44.328125 
+Q 39.84375 48.1875 33.796875 48.1875 
+Q 26.515625 48.1875 22.3125 43.546875 
+Q 18.109375 38.921875 18.109375 30.90625 
+L 18.109375 0 
+L 9.078125 0 
+L 9.078125 54.6875 
+L 18.109375 54.6875 
+L 18.109375 46.1875 
+Q 21.34375 51.125 25.703125 53.5625 
+Q 30.078125 56 35.796875 56 
+Q 45.21875 56 50.046875 50.171875 
+Q 54.890625 44.34375 54.890625 33.015625 
+z
+" id="DejaVuSans-110"/>
+      <path d="M 45.40625 46.390625 
+L 45.40625 75.984375 
+L 54.390625 75.984375 
+L 54.390625 0 
+L 45.40625 0 
+L 45.40625 8.203125 
+Q 42.578125 3.328125 38.25 0.953125 
+Q 33.9375 -1.421875 27.875 -1.421875 
+Q 17.96875 -1.421875 11.734375 6.484375 
+Q 5.515625 14.40625 5.515625 27.296875 
+Q 5.515625 40.1875 11.734375 48.09375 
+Q 17.96875 56 27.875 56 
+Q 33.9375 56 38.25 53.625 
+Q 42.578125 51.265625 45.40625 46.390625 
+z
+M 14.796875 27.296875 
+Q 14.796875 17.390625 18.875 11.75 
+Q 22.953125 6.109375 30.078125 6.109375 
+Q 37.203125 6.109375 41.296875 11.75 
+Q 45.40625 17.390625 45.40625 27.296875 
+Q 45.40625 37.203125 41.296875 42.84375 
+Q 37.203125 48.484375 30.078125 48.484375 
+Q 22.953125 48.484375 18.875 42.84375 
+Q 14.796875 37.203125 14.796875 27.296875 
+z
+" id="DejaVuSans-100"/>
+      <path d="M 56.203125 29.59375 
+L 56.203125 25.203125 
+L 14.890625 25.203125 
+Q 15.484375 15.921875 20.484375 11.0625 
+Q 25.484375 6.203125 34.421875 6.203125 
+Q 39.59375 6.203125 44.453125 7.46875 
+Q 49.3125 8.734375 54.109375 11.28125 
+L 54.109375 2.78125 
+Q 49.265625 0.734375 44.1875 -0.34375 
+Q 39.109375 -1.421875 33.890625 -1.421875 
+Q 20.796875 -1.421875 13.15625 6.1875 
+Q 5.515625 13.8125 5.515625 26.8125 
+Q 5.515625 40.234375 12.765625 48.109375 
+Q 20.015625 56 32.328125 56 
+Q 43.359375 56 49.78125 48.890625 
+Q 56.203125 41.796875 56.203125 29.59375 
+z
+M 47.21875 32.234375 
+Q 47.125 39.59375 43.09375 43.984375 
+Q 39.0625 48.390625 32.421875 48.390625 
+Q 24.90625 48.390625 20.390625 44.140625 
+Q 15.875 39.890625 15.1875 32.171875 
+z
+" id="DejaVuSans-101"/>
+      <path d="M 54.890625 54.6875 
+L 35.109375 28.078125 
+L 55.90625 0 
+L 45.3125 0 
+L 29.390625 21.484375 
+L 13.484375 0 
+L 2.875 0 
+L 24.125 28.609375 
+L 4.6875 54.6875 
+L 15.28125 54.6875 
+L 29.78125 35.203125 
+L 44.28125 54.6875 
+z
+" id="DejaVuSans-120"/>
+     </defs>
+     <g transform="translate(218.056563 284.706136)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use x="29.492188" xlink:href="#DejaVuSans-110"/>
+      <use x="92.871094" xlink:href="#DejaVuSans-100"/>
+      <use x="156.347656" xlink:href="#DejaVuSans-101"/>
+      <use x="217.855469" xlink:href="#DejaVuSans-120"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path clip-path="url(#p9b784bab91)" d="M 37.424646 223.992979 
+L 429.165354 223.992979 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path d="M 0 0 
+L 3.5 0 
+" id="mbcfa445412" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="37.424646" xlink:href="#mbcfa445412" y="223.992979"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 2.5 -->
+      <g transform="translate(21.202146 227.032354)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path clip-path="url(#p9b784bab91)" d="M 37.424646 178.698929 
+L 429.165354 178.698929 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="37.424646" xlink:href="#mbcfa445412" y="178.698929"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 5.0 -->
+      <g transform="translate(21.202146 181.738304)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-53"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path clip-path="url(#p9b784bab91)" d="M 37.424646 133.404879 
+L 429.165354 133.404879 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="37.424646" xlink:href="#mbcfa445412" y="133.404879"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 7.5 -->
+      <g transform="translate(21.202146 136.444254)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-55"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path clip-path="url(#p9b784bab91)" d="M 37.424646 88.110829 
+L 429.165354 88.110829 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="37.424646" xlink:href="#mbcfa445412" y="88.110829"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 10.0 -->
+      <g transform="translate(16.112146 91.150204)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path clip-path="url(#p9b784bab91)" d="M 37.424646 42.816779 
+L 429.165354 42.816779 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="37.424646" xlink:href="#mbcfa445412" y="42.816779"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 12.5 -->
+      <g transform="translate(16.112146 45.856154)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-50"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Value -->
+     <defs>
+      <path d="M 28.609375 0 
+L 0.78125 72.90625 
+L 11.078125 72.90625 
+L 34.1875 11.53125 
+L 57.328125 72.90625 
+L 67.578125 72.90625 
+L 39.796875 0 
+z
+" id="DejaVuSans-86"/>
+      <path d="M 34.28125 27.484375 
+Q 23.390625 27.484375 19.1875 25 
+Q 14.984375 22.515625 14.984375 16.5 
+Q 14.984375 11.71875 18.140625 8.90625 
+Q 21.296875 6.109375 26.703125 6.109375 
+Q 34.1875 6.109375 38.703125 11.40625 
+Q 43.21875 16.703125 43.21875 25.484375 
+L 43.21875 27.484375 
+z
+M 52.203125 31.203125 
+L 52.203125 0 
+L 43.21875 0 
+L 43.21875 8.296875 
+Q 40.140625 3.328125 35.546875 0.953125 
+Q 30.953125 -1.421875 24.3125 -1.421875 
+Q 15.921875 -1.421875 10.953125 3.296875 
+Q 6 8.015625 6 15.921875 
+Q 6 25.140625 12.171875 29.828125 
+Q 18.359375 34.515625 30.609375 34.515625 
+L 43.21875 34.515625 
+L 43.21875 35.40625 
+Q 43.21875 41.609375 39.140625 45 
+Q 35.0625 48.390625 27.6875 48.390625 
+Q 23 48.390625 18.546875 47.265625 
+Q 14.109375 46.140625 10.015625 43.890625 
+L 10.015625 52.203125 
+Q 14.9375 54.109375 19.578125 55.046875 
+Q 24.21875 56 28.609375 56 
+Q 40.484375 56 46.34375 49.84375 
+Q 52.203125 43.703125 52.203125 31.203125 
+z
+" id="DejaVuSans-97"/>
+      <path d="M 9.421875 75.984375 
+L 18.40625 75.984375 
+L 18.40625 0 
+L 9.421875 0 
+z
+" id="DejaVuSans-108"/>
+      <path d="M 8.5 21.578125 
+L 8.5 54.6875 
+L 17.484375 54.6875 
+L 17.484375 21.921875 
+Q 17.484375 14.15625 20.5 10.265625 
+Q 23.53125 6.390625 29.59375 6.390625 
+Q 36.859375 6.390625 41.078125 11.03125 
+Q 45.3125 15.671875 45.3125 23.6875 
+L 45.3125 54.6875 
+L 54.296875 54.6875 
+L 54.296875 0 
+L 45.3125 0 
+L 45.3125 8.40625 
+Q 42.046875 3.421875 37.71875 1 
+Q 33.40625 -1.421875 27.6875 -1.421875 
+Q 18.265625 -1.421875 13.375 4.4375 
+Q 8.5 10.296875 8.5 21.578125 
+z
+M 31.109375 56 
+z
+" id="DejaVuSans-117"/>
+     </defs>
+     <g transform="translate(9.824489 147.494609)rotate(-90)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-86"/>
+      <use x="68.298828" xlink:href="#DejaVuSans-97"/>
+      <use x="129.578125" xlink:href="#DejaVuSans-108"/>
+      <use x="157.361328" xlink:href="#DejaVuSans-117"/>
+      <use x="220.740234" xlink:href="#DejaVuSans-101"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_21">
+    <path clip-path="url(#p9b784bab91)" d="M 48.511647 251.169409 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_22">
+    <path clip-path="url(#p9b784bab91)" d="M 48.511647 253.795806 
+L 48.511647 248.543013 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m182f1995d9" style="stroke:#000000;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="48.511647" xlink:href="#m182f1995d9" y="253.795806"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="48.511647" xlink:href="#m182f1995d9" y="248.543013"/>
+    </g>
+   </g>
+   <g id="line2d_23">
+    <path clip-path="url(#p9b784bab91)" d="M 79.308872 233.051789 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_24">
+    <path clip-path="url(#p9b784bab91)" d="M 79.308872 242.88422 
+L 79.308872 223.219359 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_2">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="79.308872" xlink:href="#m182f1995d9" y="242.88422"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="79.308872" xlink:href="#m182f1995d9" y="223.219359"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 37.424646 261.105354 
+L 37.424646 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 37.424646 261.105354 
+L 429.165354 261.105354 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="line2d_25">
+    <path clip-path="url(#p9b784bab91)" d="M 110.106098 214.934169 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_26">
+    <path clip-path="url(#p9b784bab91)" d="M 110.106098 220.637712 
+L 110.106098 209.230627 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_3">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="110.106098" xlink:href="#m182f1995d9" y="220.637712"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="110.106098" xlink:href="#m182f1995d9" y="209.230627"/>
+    </g>
+   </g>
+   <g id="line2d_27">
+    <path clip-path="url(#p9b784bab91)" d="M 140.903323 196.816549 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_28">
+    <path clip-path="url(#p9b784bab91)" d="M 140.903323 206.355021 
+L 140.903323 187.278078 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_4">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="140.903323" xlink:href="#m182f1995d9" y="206.355021"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="140.903323" xlink:href="#m182f1995d9" y="187.278078"/>
+    </g>
+   </g>
+   <g id="line2d_29">
+    <path clip-path="url(#p9b784bab91)" d="M 171.700549 178.698929 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_30">
+    <path clip-path="url(#p9b784bab91)" d="M 171.700549 190.724119 
+L 171.700549 166.673739 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_5">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="171.700549" xlink:href="#m182f1995d9" y="190.724119"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="171.700549" xlink:href="#m182f1995d9" y="166.673739"/>
+    </g>
+   </g>
+   <g id="line2d_31">
+    <path clip-path="url(#p9b784bab91)" d="M 202.497774 160.581309 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_32">
+    <path clip-path="url(#p9b784bab91)" d="M 202.497774 175.43599 
+L 202.497774 145.726628 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_6">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="202.497774" xlink:href="#m182f1995d9" y="175.43599"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="202.497774" xlink:href="#m182f1995d9" y="145.726628"/>
+    </g>
+   </g>
+   <g id="line2d_33">
+    <path clip-path="url(#p9b784bab91)" d="M 233.295 142.463689 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_34">
+    <path clip-path="url(#p9b784bab91)" d="M 233.295 153.482399 
+L 233.295 131.444979 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_7">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="233.295" xlink:href="#m182f1995d9" y="153.482399"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="233.295" xlink:href="#m182f1995d9" y="131.444979"/>
+    </g>
+   </g>
+   <g id="line2d_35">
+    <path clip-path="url(#p9b784bab91)" d="M 264.092226 124.346069 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_36">
+    <path clip-path="url(#p9b784bab91)" d="M 264.092226 142.55829 
+L 264.092226 106.133849 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_8">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="264.092226" xlink:href="#m182f1995d9" y="142.55829"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="264.092226" xlink:href="#m182f1995d9" y="106.133849"/>
+    </g>
+   </g>
+   <g id="line2d_37">
+    <path clip-path="url(#p9b784bab91)" d="M 294.889451 106.228449 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_38">
+    <path clip-path="url(#p9b784bab91)" d="M 294.889451 123.399612 
+L 294.889451 89.057286 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_9">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="294.889451" xlink:href="#m182f1995d9" y="123.399612"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="294.889451" xlink:href="#m182f1995d9" y="89.057286"/>
+    </g>
+   </g>
+   <g id="line2d_39">
+    <path clip-path="url(#p9b784bab91)" d="M 325.686677 88.110829 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_40">
+    <path clip-path="url(#p9b784bab91)" d="M 325.686677 105.025777 
+L 325.686677 71.195881 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_10">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="325.686677" xlink:href="#m182f1995d9" y="105.025777"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="325.686677" xlink:href="#m182f1995d9" y="71.195881"/>
+    </g>
+   </g>
+   <g id="line2d_41">
+    <path clip-path="url(#p9b784bab91)" d="M 356.483902 69.993209 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_42">
+    <path clip-path="url(#p9b784bab91)" d="M 356.483902 91.406639 
+L 356.483902 48.579779 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_11">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="356.483902" xlink:href="#m182f1995d9" y="91.406639"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="356.483902" xlink:href="#m182f1995d9" y="48.579779"/>
+    </g>
+   </g>
+   <g id="line2d_43">
+    <path clip-path="url(#p9b784bab91)" d="M 387.281128 51.875589 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_44">
+    <path clip-path="url(#p9b784bab91)" d="M 387.281128 73.099359 
+L 387.281128 30.651819 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_12">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="387.281128" xlink:href="#m182f1995d9" y="73.099359"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="387.281128" xlink:href="#m182f1995d9" y="30.651819"/>
+    </g>
+   </g>
+   <g id="line2d_45">
+    <path clip-path="url(#p9b784bab91)" d="M 418.078353 33.757969 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_46">
+    <path clip-path="url(#p9b784bab91)" d="M 418.078353 57.371744 
+L 418.078353 10.144194 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_13">
+    <g clip-path="url(#p9b784bab91)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="418.078353" xlink:href="#m182f1995d9" y="57.371744"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="418.078353" xlink:href="#m182f1995d9" y="10.144194"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p9b784bab91">
+   <rect height="258.270709" width="391.740709" x="37.424646" y="2.834646"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/src/uncertain_datasets/uncertain_indexvalue_dataset_indices_and_vals.svg
+++ b/docs/src/uncertain_datasets/uncertain_indexvalue_dataset_indices_and_vals.svg
@@ -1,0 +1,1114 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Created with matplotlib (https://matplotlib.org/) -->
+<svg height="288pt" version="1.1" viewBox="0 0 432 288" width="432pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <style type="text/css">
+*{stroke-linecap:butt;stroke-linejoin:round;}
+  </style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 288 
+L 432 288 
+L 432 0 
+L 0 0 
+z
+" style="fill:#ffffff;"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 32.384646 261.105354 
+L 429.165354 261.105354 
+L 429.165354 2.834646 
+L 32.384646 2.834646 
+z
+" style="fill:#ffffff;"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path clip-path="url(#p1f4a2196ed)" d="M 89.231707 261.105354 
+L 89.231707 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path d="M 0 0 
+L 0 -3.5 
+" id="m021162e18a" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="89.231707" xlink:href="#m021162e18a" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 2.5 -->
+      <defs>
+       <path d="M 19.1875 8.296875 
+L 53.609375 8.296875 
+L 53.609375 0 
+L 7.328125 0 
+L 7.328125 8.296875 
+Q 12.9375 14.109375 22.625 23.890625 
+Q 32.328125 33.6875 34.8125 36.53125 
+Q 39.546875 41.84375 41.421875 45.53125 
+Q 43.3125 49.21875 43.3125 52.78125 
+Q 43.3125 58.59375 39.234375 62.25 
+Q 35.15625 65.921875 28.609375 65.921875 
+Q 23.96875 65.921875 18.8125 64.3125 
+Q 13.671875 62.703125 7.8125 59.421875 
+L 7.8125 69.390625 
+Q 13.765625 71.78125 18.9375 73 
+Q 24.125 74.21875 28.421875 74.21875 
+Q 39.75 74.21875 46.484375 68.546875 
+Q 53.21875 62.890625 53.21875 53.421875 
+Q 53.21875 48.921875 51.53125 44.890625 
+Q 49.859375 40.875 45.40625 35.40625 
+Q 44.1875 33.984375 37.640625 27.21875 
+Q 31.109375 20.453125 19.1875 8.296875 
+z
+" id="DejaVuSans-50"/>
+       <path d="M 10.6875 12.40625 
+L 21 12.40625 
+L 21 0 
+L 10.6875 0 
+z
+" id="DejaVuSans-46"/>
+       <path d="M 10.796875 72.90625 
+L 49.515625 72.90625 
+L 49.515625 64.59375 
+L 19.828125 64.59375 
+L 19.828125 46.734375 
+Q 21.96875 47.46875 24.109375 47.828125 
+Q 26.265625 48.1875 28.421875 48.1875 
+Q 40.625 48.1875 47.75 41.5 
+Q 54.890625 34.8125 54.890625 23.390625 
+Q 54.890625 11.625 47.5625 5.09375 
+Q 40.234375 -1.421875 26.90625 -1.421875 
+Q 22.3125 -1.421875 17.546875 -0.640625 
+Q 12.796875 0.140625 7.71875 1.703125 
+L 7.71875 11.625 
+Q 12.109375 9.234375 16.796875 8.0625 
+Q 21.484375 6.890625 26.703125 6.890625 
+Q 35.15625 6.890625 40.078125 11.328125 
+Q 45.015625 15.765625 45.015625 23.390625 
+Q 45.015625 31 40.078125 35.4375 
+Q 35.15625 39.890625 26.703125 39.890625 
+Q 22.75 39.890625 18.8125 39.015625 
+Q 14.890625 38.140625 10.796875 36.28125 
+z
+" id="DejaVuSans-53"/>
+      </defs>
+      <g transform="translate(82.870457 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path clip-path="url(#p1f4a2196ed)" d="M 157.406761 261.105354 
+L 157.406761 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="157.406761" xlink:href="#m021162e18a" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 5.0 -->
+      <defs>
+       <path d="M 31.78125 66.40625 
+Q 24.171875 66.40625 20.328125 58.90625 
+Q 16.5 51.421875 16.5 36.375 
+Q 16.5 21.390625 20.328125 13.890625 
+Q 24.171875 6.390625 31.78125 6.390625 
+Q 39.453125 6.390625 43.28125 13.890625 
+Q 47.125 21.390625 47.125 36.375 
+Q 47.125 51.421875 43.28125 58.90625 
+Q 39.453125 66.40625 31.78125 66.40625 
+z
+M 31.78125 74.21875 
+Q 44.046875 74.21875 50.515625 64.515625 
+Q 56.984375 54.828125 56.984375 36.375 
+Q 56.984375 17.96875 50.515625 8.265625 
+Q 44.046875 -1.421875 31.78125 -1.421875 
+Q 19.53125 -1.421875 13.0625 8.265625 
+Q 6.59375 17.96875 6.59375 36.375 
+Q 6.59375 54.828125 13.0625 64.515625 
+Q 19.53125 74.21875 31.78125 74.21875 
+z
+" id="DejaVuSans-48"/>
+      </defs>
+      <g transform="translate(151.045511 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-53"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path clip-path="url(#p1f4a2196ed)" d="M 225.581816 261.105354 
+L 225.581816 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="225.581816" xlink:href="#m021162e18a" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 7.5 -->
+      <defs>
+       <path d="M 8.203125 72.90625 
+L 55.078125 72.90625 
+L 55.078125 68.703125 
+L 28.609375 0 
+L 18.3125 0 
+L 43.21875 64.59375 
+L 8.203125 64.59375 
+z
+" id="DejaVuSans-55"/>
+      </defs>
+      <g transform="translate(219.220566 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-55"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path clip-path="url(#p1f4a2196ed)" d="M 293.756871 261.105354 
+L 293.756871 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="293.756871" xlink:href="#m021162e18a" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 10.0 -->
+      <defs>
+       <path d="M 12.40625 8.296875 
+L 28.515625 8.296875 
+L 28.515625 63.921875 
+L 10.984375 60.40625 
+L 10.984375 69.390625 
+L 28.421875 72.90625 
+L 38.28125 72.90625 
+L 38.28125 8.296875 
+L 54.390625 8.296875 
+L 54.390625 0 
+L 12.40625 0 
+z
+" id="DejaVuSans-49"/>
+      </defs>
+      <g transform="translate(284.850621 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path clip-path="url(#p1f4a2196ed)" d="M 361.931925 261.105354 
+L 361.931925 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="361.931925" xlink:href="#m021162e18a" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 12.5 -->
+      <g transform="translate(353.025675 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-50"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- Index -->
+     <defs>
+      <path d="M 9.8125 72.90625 
+L 19.671875 72.90625 
+L 19.671875 0 
+L 9.8125 0 
+z
+" id="DejaVuSans-73"/>
+      <path d="M 54.890625 33.015625 
+L 54.890625 0 
+L 45.90625 0 
+L 45.90625 32.71875 
+Q 45.90625 40.484375 42.875 44.328125 
+Q 39.84375 48.1875 33.796875 48.1875 
+Q 26.515625 48.1875 22.3125 43.546875 
+Q 18.109375 38.921875 18.109375 30.90625 
+L 18.109375 0 
+L 9.078125 0 
+L 9.078125 54.6875 
+L 18.109375 54.6875 
+L 18.109375 46.1875 
+Q 21.34375 51.125 25.703125 53.5625 
+Q 30.078125 56 35.796875 56 
+Q 45.21875 56 50.046875 50.171875 
+Q 54.890625 44.34375 54.890625 33.015625 
+z
+" id="DejaVuSans-110"/>
+      <path d="M 45.40625 46.390625 
+L 45.40625 75.984375 
+L 54.390625 75.984375 
+L 54.390625 0 
+L 45.40625 0 
+L 45.40625 8.203125 
+Q 42.578125 3.328125 38.25 0.953125 
+Q 33.9375 -1.421875 27.875 -1.421875 
+Q 17.96875 -1.421875 11.734375 6.484375 
+Q 5.515625 14.40625 5.515625 27.296875 
+Q 5.515625 40.1875 11.734375 48.09375 
+Q 17.96875 56 27.875 56 
+Q 33.9375 56 38.25 53.625 
+Q 42.578125 51.265625 45.40625 46.390625 
+z
+M 14.796875 27.296875 
+Q 14.796875 17.390625 18.875 11.75 
+Q 22.953125 6.109375 30.078125 6.109375 
+Q 37.203125 6.109375 41.296875 11.75 
+Q 45.40625 17.390625 45.40625 27.296875 
+Q 45.40625 37.203125 41.296875 42.84375 
+Q 37.203125 48.484375 30.078125 48.484375 
+Q 22.953125 48.484375 18.875 42.84375 
+Q 14.796875 37.203125 14.796875 27.296875 
+z
+" id="DejaVuSans-100"/>
+      <path d="M 56.203125 29.59375 
+L 56.203125 25.203125 
+L 14.890625 25.203125 
+Q 15.484375 15.921875 20.484375 11.0625 
+Q 25.484375 6.203125 34.421875 6.203125 
+Q 39.59375 6.203125 44.453125 7.46875 
+Q 49.3125 8.734375 54.109375 11.28125 
+L 54.109375 2.78125 
+Q 49.265625 0.734375 44.1875 -0.34375 
+Q 39.109375 -1.421875 33.890625 -1.421875 
+Q 20.796875 -1.421875 13.15625 6.1875 
+Q 5.515625 13.8125 5.515625 26.8125 
+Q 5.515625 40.234375 12.765625 48.109375 
+Q 20.015625 56 32.328125 56 
+Q 43.359375 56 49.78125 48.890625 
+Q 56.203125 41.796875 56.203125 29.59375 
+z
+M 47.21875 32.234375 
+Q 47.125 39.59375 43.09375 43.984375 
+Q 39.0625 48.390625 32.421875 48.390625 
+Q 24.90625 48.390625 20.390625 44.140625 
+Q 15.875 39.890625 15.1875 32.171875 
+z
+" id="DejaVuSans-101"/>
+      <path d="M 54.890625 54.6875 
+L 35.109375 28.078125 
+L 55.90625 0 
+L 45.3125 0 
+L 29.390625 21.484375 
+L 13.484375 0 
+L 2.875 0 
+L 24.125 28.609375 
+L 4.6875 54.6875 
+L 15.28125 54.6875 
+L 29.78125 35.203125 
+L 44.28125 54.6875 
+z
+" id="DejaVuSans-120"/>
+     </defs>
+     <g transform="translate(215.536562 284.706136)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use x="29.492188" xlink:href="#DejaVuSans-110"/>
+      <use x="92.871094" xlink:href="#DejaVuSans-100"/>
+      <use x="156.347656" xlink:href="#DejaVuSans-101"/>
+      <use x="217.855469" xlink:href="#DejaVuSans-120"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path clip-path="url(#p1f4a2196ed)" d="M 32.384646 213.423883 
+L 429.165354 213.423883 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path d="M 0 0 
+L 3.5 0 
+" id="m02b36eff85" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m02b36eff85" y="213.423883"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.0 -->
+      <g transform="translate(16.162146 216.463258)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path clip-path="url(#p1f4a2196ed)" d="M 32.384646 165.145868 
+L 429.165354 165.145868 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m02b36eff85" y="165.145868"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.3 -->
+      <defs>
+       <path d="M 40.578125 39.3125 
+Q 47.65625 37.796875 51.625 33 
+Q 55.609375 28.21875 55.609375 21.1875 
+Q 55.609375 10.40625 48.1875 4.484375 
+Q 40.765625 -1.421875 27.09375 -1.421875 
+Q 22.515625 -1.421875 17.65625 -0.515625 
+Q 12.796875 0.390625 7.625 2.203125 
+L 7.625 11.71875 
+Q 11.71875 9.328125 16.59375 8.109375 
+Q 21.484375 6.890625 26.8125 6.890625 
+Q 36.078125 6.890625 40.9375 10.546875 
+Q 45.796875 14.203125 45.796875 21.1875 
+Q 45.796875 27.640625 41.28125 31.265625 
+Q 36.765625 34.90625 28.71875 34.90625 
+L 20.21875 34.90625 
+L 20.21875 43.015625 
+L 29.109375 43.015625 
+Q 36.375 43.015625 40.234375 45.921875 
+Q 44.09375 48.828125 44.09375 54.296875 
+Q 44.09375 59.90625 40.109375 62.90625 
+Q 36.140625 65.921875 28.71875 65.921875 
+Q 24.65625 65.921875 20.015625 65.03125 
+Q 15.375 64.15625 9.8125 62.3125 
+L 9.8125 71.09375 
+Q 15.4375 72.65625 20.34375 73.4375 
+Q 25.25 74.21875 29.59375 74.21875 
+Q 40.828125 74.21875 47.359375 69.109375 
+Q 53.90625 64.015625 53.90625 55.328125 
+Q 53.90625 49.265625 50.4375 45.09375 
+Q 46.96875 40.921875 40.578125 39.3125 
+z
+" id="DejaVuSans-51"/>
+      </defs>
+      <g transform="translate(16.162146 168.185243)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-51"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path clip-path="url(#p1f4a2196ed)" d="M 32.384646 116.867852 
+L 429.165354 116.867852 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m02b36eff85" y="116.867852"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.6 -->
+      <defs>
+       <path d="M 33.015625 40.375 
+Q 26.375 40.375 22.484375 35.828125 
+Q 18.609375 31.296875 18.609375 23.390625 
+Q 18.609375 15.53125 22.484375 10.953125 
+Q 26.375 6.390625 33.015625 6.390625 
+Q 39.65625 6.390625 43.53125 10.953125 
+Q 47.40625 15.53125 47.40625 23.390625 
+Q 47.40625 31.296875 43.53125 35.828125 
+Q 39.65625 40.375 33.015625 40.375 
+z
+M 52.59375 71.296875 
+L 52.59375 62.3125 
+Q 48.875 64.0625 45.09375 64.984375 
+Q 41.3125 65.921875 37.59375 65.921875 
+Q 27.828125 65.921875 22.671875 59.328125 
+Q 17.53125 52.734375 16.796875 39.40625 
+Q 19.671875 43.65625 24.015625 45.921875 
+Q 28.375 48.1875 33.59375 48.1875 
+Q 44.578125 48.1875 50.953125 41.515625 
+Q 57.328125 34.859375 57.328125 23.390625 
+Q 57.328125 12.15625 50.6875 5.359375 
+Q 44.046875 -1.421875 33.015625 -1.421875 
+Q 20.359375 -1.421875 13.671875 8.265625 
+Q 6.984375 17.96875 6.984375 36.375 
+Q 6.984375 53.65625 15.1875 63.9375 
+Q 23.390625 74.21875 37.203125 74.21875 
+Q 40.921875 74.21875 44.703125 73.484375 
+Q 48.484375 72.75 52.59375 71.296875 
+z
+" id="DejaVuSans-54"/>
+      </defs>
+      <g transform="translate(16.162146 119.907227)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-54"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path clip-path="url(#p1f4a2196ed)" d="M 32.384646 68.589837 
+L 429.165354 68.589837 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m02b36eff85" y="68.589837"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.9 -->
+      <defs>
+       <path d="M 10.984375 1.515625 
+L 10.984375 10.5 
+Q 14.703125 8.734375 18.5 7.8125 
+Q 22.3125 6.890625 25.984375 6.890625 
+Q 35.75 6.890625 40.890625 13.453125 
+Q 46.046875 20.015625 46.78125 33.40625 
+Q 43.953125 29.203125 39.59375 26.953125 
+Q 35.25 24.703125 29.984375 24.703125 
+Q 19.046875 24.703125 12.671875 31.3125 
+Q 6.296875 37.9375 6.296875 49.421875 
+Q 6.296875 60.640625 12.9375 67.421875 
+Q 19.578125 74.21875 30.609375 74.21875 
+Q 43.265625 74.21875 49.921875 64.515625 
+Q 56.59375 54.828125 56.59375 36.375 
+Q 56.59375 19.140625 48.40625 8.859375 
+Q 40.234375 -1.421875 26.421875 -1.421875 
+Q 22.703125 -1.421875 18.890625 -0.6875 
+Q 15.09375 0.046875 10.984375 1.515625 
+z
+M 30.609375 32.421875 
+Q 37.25 32.421875 41.125 36.953125 
+Q 45.015625 41.5 45.015625 49.421875 
+Q 45.015625 57.28125 41.125 61.84375 
+Q 37.25 66.40625 30.609375 66.40625 
+Q 23.96875 66.40625 20.09375 61.84375 
+Q 16.21875 57.28125 16.21875 49.421875 
+Q 16.21875 41.5 20.09375 36.953125 
+Q 23.96875 32.421875 30.609375 32.421875 
+z
+" id="DejaVuSans-57"/>
+      </defs>
+      <g transform="translate(16.162146 71.629212)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-57"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path clip-path="url(#p1f4a2196ed)" d="M 32.384646 20.311822 
+L 429.165354 20.311822 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m02b36eff85" y="20.311822"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 1.2 -->
+      <g transform="translate(16.162146 23.351197)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-50"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Value -->
+     <defs>
+      <path d="M 28.609375 0 
+L 0.78125 72.90625 
+L 11.078125 72.90625 
+L 34.1875 11.53125 
+L 57.328125 72.90625 
+L 67.578125 72.90625 
+L 39.796875 0 
+z
+" id="DejaVuSans-86"/>
+      <path d="M 34.28125 27.484375 
+Q 23.390625 27.484375 19.1875 25 
+Q 14.984375 22.515625 14.984375 16.5 
+Q 14.984375 11.71875 18.140625 8.90625 
+Q 21.296875 6.109375 26.703125 6.109375 
+Q 34.1875 6.109375 38.703125 11.40625 
+Q 43.21875 16.703125 43.21875 25.484375 
+L 43.21875 27.484375 
+z
+M 52.203125 31.203125 
+L 52.203125 0 
+L 43.21875 0 
+L 43.21875 8.296875 
+Q 40.140625 3.328125 35.546875 0.953125 
+Q 30.953125 -1.421875 24.3125 -1.421875 
+Q 15.921875 -1.421875 10.953125 3.296875 
+Q 6 8.015625 6 15.921875 
+Q 6 25.140625 12.171875 29.828125 
+Q 18.359375 34.515625 30.609375 34.515625 
+L 43.21875 34.515625 
+L 43.21875 35.40625 
+Q 43.21875 41.609375 39.140625 45 
+Q 35.0625 48.390625 27.6875 48.390625 
+Q 23 48.390625 18.546875 47.265625 
+Q 14.109375 46.140625 10.015625 43.890625 
+L 10.015625 52.203125 
+Q 14.9375 54.109375 19.578125 55.046875 
+Q 24.21875 56 28.609375 56 
+Q 40.484375 56 46.34375 49.84375 
+Q 52.203125 43.703125 52.203125 31.203125 
+z
+" id="DejaVuSans-97"/>
+      <path d="M 9.421875 75.984375 
+L 18.40625 75.984375 
+L 18.40625 0 
+L 9.421875 0 
+z
+" id="DejaVuSans-108"/>
+      <path d="M 8.5 21.578125 
+L 8.5 54.6875 
+L 17.484375 54.6875 
+L 17.484375 21.921875 
+Q 17.484375 14.15625 20.5 10.265625 
+Q 23.53125 6.390625 29.59375 6.390625 
+Q 36.859375 6.390625 41.078125 11.03125 
+Q 45.3125 15.671875 45.3125 23.6875 
+L 45.3125 54.6875 
+L 54.296875 54.6875 
+L 54.296875 0 
+L 45.3125 0 
+L 45.3125 8.40625 
+Q 42.046875 3.421875 37.71875 1 
+Q 33.40625 -1.421875 27.6875 -1.421875 
+Q 18.265625 -1.421875 13.375 4.4375 
+Q 8.5 10.296875 8.5 21.578125 
+z
+M 31.109375 56 
+z
+" id="DejaVuSans-117"/>
+     </defs>
+     <g transform="translate(9.874489 147.494609)rotate(-90)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-86"/>
+      <use x="68.298828" xlink:href="#DejaVuSans-97"/>
+      <use x="129.578125" xlink:href="#DejaVuSans-108"/>
+      <use x="157.361328" xlink:href="#DejaVuSans-117"/>
+      <use x="220.740234" xlink:href="#DejaVuSans-101"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_21">
+    <path clip-path="url(#p1f4a2196ed)" d="M 48.326674 98.395739 
+" style="fill:none;stroke:#009afa;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_22">
+    <path clip-path="url(#p1f4a2196ed)" d="M 43.614288 98.395739 
+L 53.039059 98.395739 
+" style="fill:none;stroke:#009afa;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_23">
+    <path clip-path="url(#p1f4a2196ed)" d="M 48.326674 146.899729 
+L 48.326674 29.575342 
+" style="fill:none;stroke:#009afa;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="ma05b3495ee" style="stroke:#009afa;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#009afa;stroke:#009afa;stroke-width:1.5;" x="43.614288" xlink:href="#ma05b3495ee" y="98.395739"/>
+     <use style="fill:#009afa;stroke:#009afa;stroke-width:1.5;" x="53.039059" xlink:href="#ma05b3495ee" y="98.395739"/>
+    </g>
+   </g>
+   <g id="PathCollection_2">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m5592415ee0" style="stroke:#009afa;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#009afa;stroke:#009afa;stroke-width:1.5;" x="48.326674" xlink:href="#m5592415ee0" y="146.899729"/>
+     <use style="fill:#009afa;stroke:#009afa;stroke-width:1.5;" x="48.326674" xlink:href="#m5592415ee0" y="29.575342"/>
+    </g>
+   </g>
+   <g id="line2d_24">
+    <path clip-path="url(#p1f4a2196ed)" d="M 75.596696 122.975568 
+" style="fill:none;stroke:#e36f47;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_25">
+    <path clip-path="url(#p1f4a2196ed)" d="M 57.954958 122.975568 
+L 93.238434 122.975568 
+" style="fill:none;stroke:#e36f47;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_26">
+    <path clip-path="url(#p1f4a2196ed)" d="M 75.596696 182.481972 
+L 75.596696 66.163436 
+" style="fill:none;stroke:#e36f47;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_3">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m331818353b" style="stroke:#e36f47;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#e36f47;stroke:#e36f47;stroke-width:1.5;" x="57.954958" xlink:href="#m331818353b" y="122.975568"/>
+     <use style="fill:#e36f47;stroke:#e36f47;stroke-width:1.5;" x="93.238434" xlink:href="#m331818353b" y="122.975568"/>
+    </g>
+   </g>
+   <g id="PathCollection_4">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="mdf446c6a4f" style="stroke:#e36f47;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#e36f47;stroke:#e36f47;stroke-width:1.5;" x="75.596696" xlink:href="#mdf446c6a4f" y="182.481972"/>
+     <use style="fill:#e36f47;stroke:#e36f47;stroke-width:1.5;" x="75.596696" xlink:href="#mdf446c6a4f" y="66.163436"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 32.384646 261.105354 
+L 32.384646 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 32.384646 261.105354 
+L 429.165354 261.105354 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="line2d_27">
+    <path clip-path="url(#p1f4a2196ed)" d="M 102.866718 108.400015 
+" style="fill:none;stroke:#3ea44e;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_28">
+    <path clip-path="url(#p1f4a2196ed)" d="M 92.633195 108.400015 
+L 113.10024 108.400015 
+" style="fill:none;stroke:#3ea44e;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_29">
+    <path clip-path="url(#p1f4a2196ed)" d="M 102.866718 146.681267 
+L 102.866718 70.118763 
+" style="fill:none;stroke:#3ea44e;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_5">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m2ccc084b69" style="stroke:#3ea44e;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#3ea44e;stroke:#3ea44e;stroke-width:1.5;" x="92.633195" xlink:href="#m2ccc084b69" y="108.400015"/>
+     <use style="fill:#3ea44e;stroke:#3ea44e;stroke-width:1.5;" x="113.10024" xlink:href="#m2ccc084b69" y="108.400015"/>
+    </g>
+   </g>
+   <g id="PathCollection_6">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m7903d33ce0" style="stroke:#3ea44e;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#3ea44e;stroke:#3ea44e;stroke-width:1.5;" x="102.866718" xlink:href="#m7903d33ce0" y="146.681267"/>
+     <use style="fill:#3ea44e;stroke:#3ea44e;stroke-width:1.5;" x="102.866718" xlink:href="#m7903d33ce0" y="70.118763"/>
+    </g>
+   </g>
+   <g id="line2d_30">
+    <path clip-path="url(#p1f4a2196ed)" d="M 130.13674 80.794124 
+" style="fill:none;stroke:#c371d2;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_31">
+    <path clip-path="url(#p1f4a2196ed)" d="M 113.022434 80.794124 
+L 147.251045 80.794124 
+" style="fill:none;stroke:#c371d2;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_32">
+    <path clip-path="url(#p1f4a2196ed)" d="M 130.13674 136.647627 
+L 130.13674 24.940622 
+" style="fill:none;stroke:#c371d2;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_7">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m41b4135aa8" style="stroke:#c371d2;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#c371d2;stroke:#c371d2;stroke-width:1.5;" x="113.022434" xlink:href="#m41b4135aa8" y="80.794124"/>
+     <use style="fill:#c371d2;stroke:#c371d2;stroke-width:1.5;" x="147.251045" xlink:href="#m41b4135aa8" y="80.794124"/>
+    </g>
+   </g>
+   <g id="PathCollection_8">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m8af41a9fd4" style="stroke:#c371d2;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#c371d2;stroke:#c371d2;stroke-width:1.5;" x="130.13674" xlink:href="#m8af41a9fd4" y="136.647627"/>
+     <use style="fill:#c371d2;stroke:#c371d2;stroke-width:1.5;" x="130.13674" xlink:href="#m8af41a9fd4" y="24.940622"/>
+    </g>
+   </g>
+   <g id="line2d_33">
+    <path clip-path="url(#p1f4a2196ed)" d="M 157.406761 110.162217 
+" style="fill:none;stroke:#ac8e18;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_34">
+    <path clip-path="url(#p1f4a2196ed)" d="M 135.830687 110.162217 
+L 178.982836 110.162217 
+" style="fill:none;stroke:#ac8e18;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_35">
+    <path clip-path="url(#p1f4a2196ed)" d="M 157.406761 171.910352 
+L 157.406761 48.414082 
+" style="fill:none;stroke:#ac8e18;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_9">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="mce61bb2981" style="stroke:#ac8e18;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#ac8e18;stroke:#ac8e18;stroke-width:1.5;" x="135.830687" xlink:href="#mce61bb2981" y="110.162217"/>
+     <use style="fill:#ac8e18;stroke:#ac8e18;stroke-width:1.5;" x="178.982836" xlink:href="#mce61bb2981" y="110.162217"/>
+    </g>
+   </g>
+   <g id="PathCollection_10">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="mfdadf8b496" style="stroke:#ac8e18;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#ac8e18;stroke:#ac8e18;stroke-width:1.5;" x="157.406761" xlink:href="#mfdadf8b496" y="171.910352"/>
+     <use style="fill:#ac8e18;stroke:#ac8e18;stroke-width:1.5;" x="157.406761" xlink:href="#mfdadf8b496" y="48.414082"/>
+    </g>
+   </g>
+   <g id="line2d_36">
+    <path clip-path="url(#p1f4a2196ed)" d="M 184.676783 124.345514 
+" style="fill:none;stroke:#00aaae;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_37">
+    <path clip-path="url(#p1f4a2196ed)" d="M 158.023923 124.345514 
+L 211.329643 124.345514 
+" style="fill:none;stroke:#00aaae;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_38">
+    <path clip-path="url(#p1f4a2196ed)" d="M 184.676783 174.153176 
+L 184.676783 74.537852 
+" style="fill:none;stroke:#00aaae;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_11">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m982e3fda9f" style="stroke:#00aaae;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#00aaae;stroke:#00aaae;stroke-width:1.5;" x="158.023923" xlink:href="#m982e3fda9f" y="124.345514"/>
+     <use style="fill:#00aaae;stroke:#00aaae;stroke-width:1.5;" x="211.329643" xlink:href="#m982e3fda9f" y="124.345514"/>
+    </g>
+   </g>
+   <g id="PathCollection_12">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m8f5504b6e0" style="stroke:#00aaae;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#00aaae;stroke:#00aaae;stroke-width:1.5;" x="184.676783" xlink:href="#m8f5504b6e0" y="174.153176"/>
+     <use style="fill:#00aaae;stroke:#00aaae;stroke-width:1.5;" x="184.676783" xlink:href="#m8f5504b6e0" y="74.537852"/>
+    </g>
+   </g>
+   <g id="line2d_39">
+    <path clip-path="url(#p1f4a2196ed)" d="M 211.946805 202.972964 
+" style="fill:none;stroke:#ed5e93;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_40">
+    <path clip-path="url(#p1f4a2196ed)" d="M 192.176597 202.972964 
+L 231.717014 202.972964 
+" style="fill:none;stroke:#ed5e93;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_41">
+    <path clip-path="url(#p1f4a2196ed)" d="M 211.946805 209.923014 
+L 211.946805 196.022914 
+" style="fill:none;stroke:#ed5e93;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_13">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="meb32c6657c" style="stroke:#ed5e93;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#ed5e93;stroke:#ed5e93;stroke-width:1.5;" x="192.176597" xlink:href="#meb32c6657c" y="202.972964"/>
+     <use style="fill:#ed5e93;stroke:#ed5e93;stroke-width:1.5;" x="231.717014" xlink:href="#meb32c6657c" y="202.972964"/>
+    </g>
+   </g>
+   <g id="PathCollection_14">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m243074d95e" style="stroke:#ed5e93;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#ed5e93;stroke:#ed5e93;stroke-width:1.5;" x="211.946805" xlink:href="#m243074d95e" y="209.923014"/>
+     <use style="fill:#ed5e93;stroke:#ed5e93;stroke-width:1.5;" x="211.946805" xlink:href="#m243074d95e" y="196.022914"/>
+    </g>
+   </g>
+   <g id="line2d_42">
+    <path clip-path="url(#p1f4a2196ed)" d="M 239.216827 73.613781 
+" style="fill:none;stroke:#c68225;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_43">
+    <path clip-path="url(#p1f4a2196ed)" d="M 206.539736 73.613781 
+L 271.893918 73.613781 
+" style="fill:none;stroke:#c68225;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_44">
+    <path clip-path="url(#p1f4a2196ed)" d="M 239.216827 124.017351 
+L 239.216827 23.21021 
+" style="fill:none;stroke:#c68225;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_15">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m264e962db7" style="stroke:#c68225;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#c68225;stroke:#c68225;stroke-width:1.5;" x="206.539736" xlink:href="#m264e962db7" y="73.613781"/>
+     <use style="fill:#c68225;stroke:#c68225;stroke-width:1.5;" x="271.893918" xlink:href="#m264e962db7" y="73.613781"/>
+    </g>
+   </g>
+   <g id="PathCollection_16">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m08dcd4fab0" style="stroke:#c68225;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#c68225;stroke:#c68225;stroke-width:1.5;" x="239.216827" xlink:href="#m08dcd4fab0" y="124.017351"/>
+     <use style="fill:#c68225;stroke:#c68225;stroke-width:1.5;" x="239.216827" xlink:href="#m08dcd4fab0" y="23.21021"/>
+    </g>
+   </g>
+   <g id="line2d_45">
+    <path clip-path="url(#p1f4a2196ed)" d="M 266.486849 76.597164 
+" style="fill:none;stroke:#00a98d;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_46">
+    <path clip-path="url(#p1f4a2196ed)" d="M 235.677665 76.597164 
+L 297.296033 76.597164 
+" style="fill:none;stroke:#00a98d;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_47">
+    <path clip-path="url(#p1f4a2196ed)" d="M 266.486849 143.050134 
+L 266.486849 10.144194 
+" style="fill:none;stroke:#00a98d;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_17">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="maa4d547164" style="stroke:#00a98d;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#00a98d;stroke:#00a98d;stroke-width:1.5;" x="235.677665" xlink:href="#maa4d547164" y="76.597164"/>
+     <use style="fill:#00a98d;stroke:#00a98d;stroke-width:1.5;" x="297.296033" xlink:href="#maa4d547164" y="76.597164"/>
+    </g>
+   </g>
+   <g id="PathCollection_18">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="ma0d5b66a59" style="stroke:#00a98d;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#00a98d;stroke:#00a98d;stroke-width:1.5;" x="266.486849" xlink:href="#ma0d5b66a59" y="143.050134"/>
+     <use style="fill:#00a98d;stroke:#00a98d;stroke-width:1.5;" x="266.486849" xlink:href="#ma0d5b66a59" y="10.144194"/>
+    </g>
+   </g>
+   <g id="line2d_48">
+    <path clip-path="url(#p1f4a2196ed)" d="M 293.756871 160.417625 
+" style="fill:none;stroke:#8e971e;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_49">
+    <path clip-path="url(#p1f4a2196ed)" d="M 263.407398 160.417625 
+L 324.106343 160.417625 
+" style="fill:none;stroke:#8e971e;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_50">
+    <path clip-path="url(#p1f4a2196ed)" d="M 293.756871 190.343681 
+L 293.756871 130.491569 
+" style="fill:none;stroke:#8e971e;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_19">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="mbcfeb56be6" style="stroke:#8e971e;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#8e971e;stroke:#8e971e;stroke-width:1.5;" x="263.407398" xlink:href="#mbcfeb56be6" y="160.417625"/>
+     <use style="fill:#8e971e;stroke:#8e971e;stroke-width:1.5;" x="324.106343" xlink:href="#mbcfeb56be6" y="160.417625"/>
+    </g>
+   </g>
+   <g id="PathCollection_20">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m6752c03eba" style="stroke:#8e971e;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#8e971e;stroke:#8e971e;stroke-width:1.5;" x="293.756871" xlink:href="#m6752c03eba" y="190.343681"/>
+     <use style="fill:#8e971e;stroke:#8e971e;stroke-width:1.5;" x="293.756871" xlink:href="#m6752c03eba" y="130.491569"/>
+    </g>
+   </g>
+   <g id="line2d_51">
+    <path clip-path="url(#p1f4a2196ed)" d="M 321.026893 52.533505 
+" style="fill:none;stroke:#00a9cc;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_52">
+    <path clip-path="url(#p1f4a2196ed)" d="M 282.606065 52.533505 
+L 359.447721 52.533505 
+" style="fill:none;stroke:#00a9cc;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_53">
+    <path clip-path="url(#p1f4a2196ed)" d="M 321.026893 88.15603 
+L 321.026893 16.910981 
+" style="fill:none;stroke:#00a9cc;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_21">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m92f953af19" style="stroke:#00a9cc;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#00a9cc;stroke:#00a9cc;stroke-width:1.5;" x="282.606065" xlink:href="#m92f953af19" y="52.533505"/>
+     <use style="fill:#00a9cc;stroke:#00a9cc;stroke-width:1.5;" x="359.447721" xlink:href="#m92f953af19" y="52.533505"/>
+    </g>
+   </g>
+   <g id="PathCollection_22">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m691ddf4490" style="stroke:#00a9cc;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#00a9cc;stroke:#00a9cc;stroke-width:1.5;" x="321.026893" xlink:href="#m691ddf4490" y="88.15603"/>
+     <use style="fill:#00a9cc;stroke:#00a9cc;stroke-width:1.5;" x="321.026893" xlink:href="#m691ddf4490" y="16.910981"/>
+    </g>
+   </g>
+   <g id="line2d_54">
+    <path clip-path="url(#p1f4a2196ed)" d="M 348.296915 204.684564 
+" style="fill:none;stroke:#9b7fe9;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_55">
+    <path clip-path="url(#p1f4a2196ed)" d="M 310.216381 204.684564 
+L 386.377448 204.684564 
+" style="fill:none;stroke:#9b7fe9;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_56">
+    <path clip-path="url(#p1f4a2196ed)" d="M 348.296915 253.795806 
+L 348.296915 155.573323 
+" style="fill:none;stroke:#9b7fe9;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_23">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m14424e914b" style="stroke:#9b7fe9;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#9b7fe9;stroke:#9b7fe9;stroke-width:1.5;" x="310.216381" xlink:href="#m14424e914b" y="204.684564"/>
+     <use style="fill:#9b7fe9;stroke:#9b7fe9;stroke-width:1.5;" x="386.377448" xlink:href="#m14424e914b" y="204.684564"/>
+    </g>
+   </g>
+   <g id="PathCollection_24">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m357c600808" style="stroke:#9b7fe9;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#9b7fe9;stroke:#9b7fe9;stroke-width:1.5;" x="348.296915" xlink:href="#m357c600808" y="253.795806"/>
+     <use style="fill:#9b7fe9;stroke:#9b7fe9;stroke-width:1.5;" x="348.296915" xlink:href="#m357c600808" y="155.573323"/>
+    </g>
+   </g>
+   <g id="line2d_57">
+    <path clip-path="url(#p1f4a2196ed)" d="M 375.566936 147.600656 
+" style="fill:none;stroke:#618df6;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_58">
+    <path clip-path="url(#p1f4a2196ed)" d="M 333.198161 147.600656 
+L 417.935712 147.600656 
+" style="fill:none;stroke:#618df6;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_59">
+    <path clip-path="url(#p1f4a2196ed)" d="M 375.566936 157.331684 
+L 375.566936 137.869629 
+" style="fill:none;stroke:#618df6;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_25">
+    <defs>
+     <path d="M 0 2 
+L 0 -2 
+" id="m357ca2659f" style="stroke:#618df6;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#618df6;stroke:#618df6;stroke-width:1.5;" x="333.198161" xlink:href="#m357ca2659f" y="147.600656"/>
+     <use style="fill:#618df6;stroke:#618df6;stroke-width:1.5;" x="417.935712" xlink:href="#m357ca2659f" y="147.600656"/>
+    </g>
+   </g>
+   <g id="PathCollection_26">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m612e748854" style="stroke:#618df6;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p1f4a2196ed)">
+     <use style="fill:#618df6;stroke:#618df6;stroke-width:1.5;" x="375.566936" xlink:href="#m612e748854" y="157.331684"/>
+     <use style="fill:#618df6;stroke:#618df6;stroke-width:1.5;" x="375.566936" xlink:href="#m612e748854" y="137.869629"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p1f4a2196ed">
+   <rect height="258.270709" width="396.780709" x="32.384646" y="2.834646"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/src/uncertain_datasets/uncertain_indexvalue_dataset_vals.svg
+++ b/docs/src/uncertain_datasets/uncertain_indexvalue_dataset_vals.svg
@@ -1,0 +1,846 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Created with matplotlib (https://matplotlib.org/) -->
+<svg height="288pt" version="1.1" viewBox="0 0 432 288" width="432pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <style type="text/css">
+*{stroke-linecap:butt;stroke-linejoin:round;}
+  </style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 288 
+L 432 288 
+L 432 0 
+L 0 0 
+z
+" style="fill:#ffffff;"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 32.384646 261.105354 
+L 429.165354 261.105354 
+L 429.165354 2.834646 
+L 32.384646 2.834646 
+z
+" style="fill:#ffffff;"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path clip-path="url(#p51484aca56)" d="M 90.404466 261.105354 
+L 90.404466 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path d="M 0 0 
+L 0 -3.5 
+" id="m1ccdeae2f8" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="90.404466" xlink:href="#m1ccdeae2f8" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 2.5 -->
+      <defs>
+       <path d="M 19.1875 8.296875 
+L 53.609375 8.296875 
+L 53.609375 0 
+L 7.328125 0 
+L 7.328125 8.296875 
+Q 12.9375 14.109375 22.625 23.890625 
+Q 32.328125 33.6875 34.8125 36.53125 
+Q 39.546875 41.84375 41.421875 45.53125 
+Q 43.3125 49.21875 43.3125 52.78125 
+Q 43.3125 58.59375 39.234375 62.25 
+Q 35.15625 65.921875 28.609375 65.921875 
+Q 23.96875 65.921875 18.8125 64.3125 
+Q 13.671875 62.703125 7.8125 59.421875 
+L 7.8125 69.390625 
+Q 13.765625 71.78125 18.9375 73 
+Q 24.125 74.21875 28.421875 74.21875 
+Q 39.75 74.21875 46.484375 68.546875 
+Q 53.21875 62.890625 53.21875 53.421875 
+Q 53.21875 48.921875 51.53125 44.890625 
+Q 49.859375 40.875 45.40625 35.40625 
+Q 44.1875 33.984375 37.640625 27.21875 
+Q 31.109375 20.453125 19.1875 8.296875 
+z
+" id="DejaVuSans-50"/>
+       <path d="M 10.6875 12.40625 
+L 21 12.40625 
+L 21 0 
+L 10.6875 0 
+z
+" id="DejaVuSans-46"/>
+       <path d="M 10.796875 72.90625 
+L 49.515625 72.90625 
+L 49.515625 64.59375 
+L 19.828125 64.59375 
+L 19.828125 46.734375 
+Q 21.96875 47.46875 24.109375 47.828125 
+Q 26.265625 48.1875 28.421875 48.1875 
+Q 40.625 48.1875 47.75 41.5 
+Q 54.890625 34.8125 54.890625 23.390625 
+Q 54.890625 11.625 47.5625 5.09375 
+Q 40.234375 -1.421875 26.90625 -1.421875 
+Q 22.3125 -1.421875 17.546875 -0.640625 
+Q 12.796875 0.140625 7.71875 1.703125 
+L 7.71875 11.625 
+Q 12.109375 9.234375 16.796875 8.0625 
+Q 21.484375 6.890625 26.703125 6.890625 
+Q 35.15625 6.890625 40.078125 11.328125 
+Q 45.015625 15.765625 45.015625 23.390625 
+Q 45.015625 31 40.078125 35.4375 
+Q 35.15625 39.890625 26.703125 39.890625 
+Q 22.75 39.890625 18.8125 39.015625 
+Q 14.890625 38.140625 10.796875 36.28125 
+z
+" id="DejaVuSans-53"/>
+      </defs>
+      <g transform="translate(84.043216 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path clip-path="url(#p51484aca56)" d="M 168.388096 261.105354 
+L 168.388096 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="168.388096" xlink:href="#m1ccdeae2f8" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 5.0 -->
+      <defs>
+       <path d="M 31.78125 66.40625 
+Q 24.171875 66.40625 20.328125 58.90625 
+Q 16.5 51.421875 16.5 36.375 
+Q 16.5 21.390625 20.328125 13.890625 
+Q 24.171875 6.390625 31.78125 6.390625 
+Q 39.453125 6.390625 43.28125 13.890625 
+Q 47.125 21.390625 47.125 36.375 
+Q 47.125 51.421875 43.28125 58.90625 
+Q 39.453125 66.40625 31.78125 66.40625 
+z
+M 31.78125 74.21875 
+Q 44.046875 74.21875 50.515625 64.515625 
+Q 56.984375 54.828125 56.984375 36.375 
+Q 56.984375 17.96875 50.515625 8.265625 
+Q 44.046875 -1.421875 31.78125 -1.421875 
+Q 19.53125 -1.421875 13.0625 8.265625 
+Q 6.59375 17.96875 6.59375 36.375 
+Q 6.59375 54.828125 13.0625 64.515625 
+Q 19.53125 74.21875 31.78125 74.21875 
+z
+" id="DejaVuSans-48"/>
+      </defs>
+      <g transform="translate(162.026846 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-53"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path clip-path="url(#p51484aca56)" d="M 246.371726 261.105354 
+L 246.371726 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="246.371726" xlink:href="#m1ccdeae2f8" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 7.5 -->
+      <defs>
+       <path d="M 8.203125 72.90625 
+L 55.078125 72.90625 
+L 55.078125 68.703125 
+L 28.609375 0 
+L 18.3125 0 
+L 43.21875 64.59375 
+L 8.203125 64.59375 
+z
+" id="DejaVuSans-55"/>
+      </defs>
+      <g transform="translate(240.010476 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-55"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path clip-path="url(#p51484aca56)" d="M 324.355356 261.105354 
+L 324.355356 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="324.355356" xlink:href="#m1ccdeae2f8" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 10.0 -->
+      <defs>
+       <path d="M 12.40625 8.296875 
+L 28.515625 8.296875 
+L 28.515625 63.921875 
+L 10.984375 60.40625 
+L 10.984375 69.390625 
+L 28.421875 72.90625 
+L 38.28125 72.90625 
+L 38.28125 8.296875 
+L 54.390625 8.296875 
+L 54.390625 0 
+L 12.40625 0 
+z
+" id="DejaVuSans-49"/>
+      </defs>
+      <g transform="translate(315.449106 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path clip-path="url(#p51484aca56)" d="M 402.338986 261.105354 
+L 402.338986 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="402.338986" xlink:href="#m1ccdeae2f8" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 12.5 -->
+      <g transform="translate(393.432736 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-50"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-46"/>
+       <use x="159.033203" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- Index -->
+     <defs>
+      <path d="M 9.8125 72.90625 
+L 19.671875 72.90625 
+L 19.671875 0 
+L 9.8125 0 
+z
+" id="DejaVuSans-73"/>
+      <path d="M 54.890625 33.015625 
+L 54.890625 0 
+L 45.90625 0 
+L 45.90625 32.71875 
+Q 45.90625 40.484375 42.875 44.328125 
+Q 39.84375 48.1875 33.796875 48.1875 
+Q 26.515625 48.1875 22.3125 43.546875 
+Q 18.109375 38.921875 18.109375 30.90625 
+L 18.109375 0 
+L 9.078125 0 
+L 9.078125 54.6875 
+L 18.109375 54.6875 
+L 18.109375 46.1875 
+Q 21.34375 51.125 25.703125 53.5625 
+Q 30.078125 56 35.796875 56 
+Q 45.21875 56 50.046875 50.171875 
+Q 54.890625 44.34375 54.890625 33.015625 
+z
+" id="DejaVuSans-110"/>
+      <path d="M 45.40625 46.390625 
+L 45.40625 75.984375 
+L 54.390625 75.984375 
+L 54.390625 0 
+L 45.40625 0 
+L 45.40625 8.203125 
+Q 42.578125 3.328125 38.25 0.953125 
+Q 33.9375 -1.421875 27.875 -1.421875 
+Q 17.96875 -1.421875 11.734375 6.484375 
+Q 5.515625 14.40625 5.515625 27.296875 
+Q 5.515625 40.1875 11.734375 48.09375 
+Q 17.96875 56 27.875 56 
+Q 33.9375 56 38.25 53.625 
+Q 42.578125 51.265625 45.40625 46.390625 
+z
+M 14.796875 27.296875 
+Q 14.796875 17.390625 18.875 11.75 
+Q 22.953125 6.109375 30.078125 6.109375 
+Q 37.203125 6.109375 41.296875 11.75 
+Q 45.40625 17.390625 45.40625 27.296875 
+Q 45.40625 37.203125 41.296875 42.84375 
+Q 37.203125 48.484375 30.078125 48.484375 
+Q 22.953125 48.484375 18.875 42.84375 
+Q 14.796875 37.203125 14.796875 27.296875 
+z
+" id="DejaVuSans-100"/>
+      <path d="M 56.203125 29.59375 
+L 56.203125 25.203125 
+L 14.890625 25.203125 
+Q 15.484375 15.921875 20.484375 11.0625 
+Q 25.484375 6.203125 34.421875 6.203125 
+Q 39.59375 6.203125 44.453125 7.46875 
+Q 49.3125 8.734375 54.109375 11.28125 
+L 54.109375 2.78125 
+Q 49.265625 0.734375 44.1875 -0.34375 
+Q 39.109375 -1.421875 33.890625 -1.421875 
+Q 20.796875 -1.421875 13.15625 6.1875 
+Q 5.515625 13.8125 5.515625 26.8125 
+Q 5.515625 40.234375 12.765625 48.109375 
+Q 20.015625 56 32.328125 56 
+Q 43.359375 56 49.78125 48.890625 
+Q 56.203125 41.796875 56.203125 29.59375 
+z
+M 47.21875 32.234375 
+Q 47.125 39.59375 43.09375 43.984375 
+Q 39.0625 48.390625 32.421875 48.390625 
+Q 24.90625 48.390625 20.390625 44.140625 
+Q 15.875 39.890625 15.1875 32.171875 
+z
+" id="DejaVuSans-101"/>
+      <path d="M 54.890625 54.6875 
+L 35.109375 28.078125 
+L 55.90625 0 
+L 45.3125 0 
+L 29.390625 21.484375 
+L 13.484375 0 
+L 2.875 0 
+L 24.125 28.609375 
+L 4.6875 54.6875 
+L 15.28125 54.6875 
+L 29.78125 35.203125 
+L 44.28125 54.6875 
+z
+" id="DejaVuSans-120"/>
+     </defs>
+     <g transform="translate(215.536562 284.706136)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use x="29.492188" xlink:href="#DejaVuSans-110"/>
+      <use x="92.871094" xlink:href="#DejaVuSans-100"/>
+      <use x="156.347656" xlink:href="#DejaVuSans-101"/>
+      <use x="217.855469" xlink:href="#DejaVuSans-120"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path clip-path="url(#p51484aca56)" d="M 32.384646 213.423883 
+L 429.165354 213.423883 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path d="M 0 0 
+L 3.5 0 
+" id="m03bc9c26ba" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m03bc9c26ba" y="213.423883"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.0 -->
+      <g transform="translate(16.162146 216.463258)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path clip-path="url(#p51484aca56)" d="M 32.384646 165.145868 
+L 429.165354 165.145868 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m03bc9c26ba" y="165.145868"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.3 -->
+      <defs>
+       <path d="M 40.578125 39.3125 
+Q 47.65625 37.796875 51.625 33 
+Q 55.609375 28.21875 55.609375 21.1875 
+Q 55.609375 10.40625 48.1875 4.484375 
+Q 40.765625 -1.421875 27.09375 -1.421875 
+Q 22.515625 -1.421875 17.65625 -0.515625 
+Q 12.796875 0.390625 7.625 2.203125 
+L 7.625 11.71875 
+Q 11.71875 9.328125 16.59375 8.109375 
+Q 21.484375 6.890625 26.8125 6.890625 
+Q 36.078125 6.890625 40.9375 10.546875 
+Q 45.796875 14.203125 45.796875 21.1875 
+Q 45.796875 27.640625 41.28125 31.265625 
+Q 36.765625 34.90625 28.71875 34.90625 
+L 20.21875 34.90625 
+L 20.21875 43.015625 
+L 29.109375 43.015625 
+Q 36.375 43.015625 40.234375 45.921875 
+Q 44.09375 48.828125 44.09375 54.296875 
+Q 44.09375 59.90625 40.109375 62.90625 
+Q 36.140625 65.921875 28.71875 65.921875 
+Q 24.65625 65.921875 20.015625 65.03125 
+Q 15.375 64.15625 9.8125 62.3125 
+L 9.8125 71.09375 
+Q 15.4375 72.65625 20.34375 73.4375 
+Q 25.25 74.21875 29.59375 74.21875 
+Q 40.828125 74.21875 47.359375 69.109375 
+Q 53.90625 64.015625 53.90625 55.328125 
+Q 53.90625 49.265625 50.4375 45.09375 
+Q 46.96875 40.921875 40.578125 39.3125 
+z
+" id="DejaVuSans-51"/>
+      </defs>
+      <g transform="translate(16.162146 168.185243)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-51"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path clip-path="url(#p51484aca56)" d="M 32.384646 116.867852 
+L 429.165354 116.867852 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m03bc9c26ba" y="116.867852"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.6 -->
+      <defs>
+       <path d="M 33.015625 40.375 
+Q 26.375 40.375 22.484375 35.828125 
+Q 18.609375 31.296875 18.609375 23.390625 
+Q 18.609375 15.53125 22.484375 10.953125 
+Q 26.375 6.390625 33.015625 6.390625 
+Q 39.65625 6.390625 43.53125 10.953125 
+Q 47.40625 15.53125 47.40625 23.390625 
+Q 47.40625 31.296875 43.53125 35.828125 
+Q 39.65625 40.375 33.015625 40.375 
+z
+M 52.59375 71.296875 
+L 52.59375 62.3125 
+Q 48.875 64.0625 45.09375 64.984375 
+Q 41.3125 65.921875 37.59375 65.921875 
+Q 27.828125 65.921875 22.671875 59.328125 
+Q 17.53125 52.734375 16.796875 39.40625 
+Q 19.671875 43.65625 24.015625 45.921875 
+Q 28.375 48.1875 33.59375 48.1875 
+Q 44.578125 48.1875 50.953125 41.515625 
+Q 57.328125 34.859375 57.328125 23.390625 
+Q 57.328125 12.15625 50.6875 5.359375 
+Q 44.046875 -1.421875 33.015625 -1.421875 
+Q 20.359375 -1.421875 13.671875 8.265625 
+Q 6.984375 17.96875 6.984375 36.375 
+Q 6.984375 53.65625 15.1875 63.9375 
+Q 23.390625 74.21875 37.203125 74.21875 
+Q 40.921875 74.21875 44.703125 73.484375 
+Q 48.484375 72.75 52.59375 71.296875 
+z
+" id="DejaVuSans-54"/>
+      </defs>
+      <g transform="translate(16.162146 119.907227)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-54"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path clip-path="url(#p51484aca56)" d="M 32.384646 68.589837 
+L 429.165354 68.589837 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m03bc9c26ba" y="68.589837"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.9 -->
+      <defs>
+       <path d="M 10.984375 1.515625 
+L 10.984375 10.5 
+Q 14.703125 8.734375 18.5 7.8125 
+Q 22.3125 6.890625 25.984375 6.890625 
+Q 35.75 6.890625 40.890625 13.453125 
+Q 46.046875 20.015625 46.78125 33.40625 
+Q 43.953125 29.203125 39.59375 26.953125 
+Q 35.25 24.703125 29.984375 24.703125 
+Q 19.046875 24.703125 12.671875 31.3125 
+Q 6.296875 37.9375 6.296875 49.421875 
+Q 6.296875 60.640625 12.9375 67.421875 
+Q 19.578125 74.21875 30.609375 74.21875 
+Q 43.265625 74.21875 49.921875 64.515625 
+Q 56.59375 54.828125 56.59375 36.375 
+Q 56.59375 19.140625 48.40625 8.859375 
+Q 40.234375 -1.421875 26.421875 -1.421875 
+Q 22.703125 -1.421875 18.890625 -0.6875 
+Q 15.09375 0.046875 10.984375 1.515625 
+z
+M 30.609375 32.421875 
+Q 37.25 32.421875 41.125 36.953125 
+Q 45.015625 41.5 45.015625 49.421875 
+Q 45.015625 57.28125 41.125 61.84375 
+Q 37.25 66.40625 30.609375 66.40625 
+Q 23.96875 66.40625 20.09375 61.84375 
+Q 16.21875 57.28125 16.21875 49.421875 
+Q 16.21875 41.5 20.09375 36.953125 
+Q 23.96875 32.421875 30.609375 32.421875 
+z
+" id="DejaVuSans-57"/>
+      </defs>
+      <g transform="translate(16.162146 71.629212)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-57"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path clip-path="url(#p51484aca56)" d="M 32.384646 20.311822 
+L 429.165354 20.311822 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="32.384646" xlink:href="#m03bc9c26ba" y="20.311822"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 1.2 -->
+      <g transform="translate(16.162146 23.351197)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-46"/>
+       <use x="95.410156" xlink:href="#DejaVuSans-50"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Value -->
+     <defs>
+      <path d="M 28.609375 0 
+L 0.78125 72.90625 
+L 11.078125 72.90625 
+L 34.1875 11.53125 
+L 57.328125 72.90625 
+L 67.578125 72.90625 
+L 39.796875 0 
+z
+" id="DejaVuSans-86"/>
+      <path d="M 34.28125 27.484375 
+Q 23.390625 27.484375 19.1875 25 
+Q 14.984375 22.515625 14.984375 16.5 
+Q 14.984375 11.71875 18.140625 8.90625 
+Q 21.296875 6.109375 26.703125 6.109375 
+Q 34.1875 6.109375 38.703125 11.40625 
+Q 43.21875 16.703125 43.21875 25.484375 
+L 43.21875 27.484375 
+z
+M 52.203125 31.203125 
+L 52.203125 0 
+L 43.21875 0 
+L 43.21875 8.296875 
+Q 40.140625 3.328125 35.546875 0.953125 
+Q 30.953125 -1.421875 24.3125 -1.421875 
+Q 15.921875 -1.421875 10.953125 3.296875 
+Q 6 8.015625 6 15.921875 
+Q 6 25.140625 12.171875 29.828125 
+Q 18.359375 34.515625 30.609375 34.515625 
+L 43.21875 34.515625 
+L 43.21875 35.40625 
+Q 43.21875 41.609375 39.140625 45 
+Q 35.0625 48.390625 27.6875 48.390625 
+Q 23 48.390625 18.546875 47.265625 
+Q 14.109375 46.140625 10.015625 43.890625 
+L 10.015625 52.203125 
+Q 14.9375 54.109375 19.578125 55.046875 
+Q 24.21875 56 28.609375 56 
+Q 40.484375 56 46.34375 49.84375 
+Q 52.203125 43.703125 52.203125 31.203125 
+z
+" id="DejaVuSans-97"/>
+      <path d="M 9.421875 75.984375 
+L 18.40625 75.984375 
+L 18.40625 0 
+L 9.421875 0 
+z
+" id="DejaVuSans-108"/>
+      <path d="M 8.5 21.578125 
+L 8.5 54.6875 
+L 17.484375 54.6875 
+L 17.484375 21.921875 
+Q 17.484375 14.15625 20.5 10.265625 
+Q 23.53125 6.390625 29.59375 6.390625 
+Q 36.859375 6.390625 41.078125 11.03125 
+Q 45.3125 15.671875 45.3125 23.6875 
+L 45.3125 54.6875 
+L 54.296875 54.6875 
+L 54.296875 0 
+L 45.3125 0 
+L 45.3125 8.40625 
+Q 42.046875 3.421875 37.71875 1 
+Q 33.40625 -1.421875 27.6875 -1.421875 
+Q 18.265625 -1.421875 13.375 4.4375 
+Q 8.5 10.296875 8.5 21.578125 
+z
+M 31.109375 56 
+z
+" id="DejaVuSans-117"/>
+     </defs>
+     <g transform="translate(9.874489 147.494609)rotate(-90)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-86"/>
+      <use x="68.298828" xlink:href="#DejaVuSans-97"/>
+      <use x="129.578125" xlink:href="#DejaVuSans-108"/>
+      <use x="157.361328" xlink:href="#DejaVuSans-117"/>
+      <use x="220.740234" xlink:href="#DejaVuSans-101"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_21">
+    <path clip-path="url(#p51484aca56)" d="M 43.614288 98.395739 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_22">
+    <path clip-path="url(#p51484aca56)" d="M 43.614288 146.899729 
+L 43.614288 29.575342 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="m738a896821" style="stroke:#000000;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="43.614288" xlink:href="#m738a896821" y="146.899729"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="43.614288" xlink:href="#m738a896821" y="29.575342"/>
+    </g>
+   </g>
+   <g id="line2d_23">
+    <path clip-path="url(#p51484aca56)" d="M 74.80774 121.241883 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_24">
+    <path clip-path="url(#p51484aca56)" d="M 74.80774 182.458159 
+L 74.80774 68.707119 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_2">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="74.80774" xlink:href="#m738a896821" y="182.458159"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="74.80774" xlink:href="#m738a896821" y="68.707119"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 32.384646 261.105354 
+L 32.384646 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 32.384646 261.105354 
+L 429.165354 261.105354 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="line2d_25">
+    <path clip-path="url(#p51484aca56)" d="M 106.001192 108.400015 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_26">
+    <path clip-path="url(#p51484aca56)" d="M 106.001192 146.681267 
+L 106.001192 70.118763 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_3">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="106.001192" xlink:href="#m738a896821" y="146.681267"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="106.001192" xlink:href="#m738a896821" y="70.118763"/>
+    </g>
+   </g>
+   <g id="line2d_27">
+    <path clip-path="url(#p51484aca56)" d="M 137.194644 80.794124 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_28">
+    <path clip-path="url(#p51484aca56)" d="M 137.194644 136.647627 
+L 137.194644 24.940622 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_4">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="137.194644" xlink:href="#m738a896821" y="136.647627"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="137.194644" xlink:href="#m738a896821" y="24.940622"/>
+    </g>
+   </g>
+   <g id="line2d_29">
+    <path clip-path="url(#p51484aca56)" d="M 168.388096 110.162217 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_30">
+    <path clip-path="url(#p51484aca56)" d="M 168.388096 171.910352 
+L 168.388096 48.414082 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_5">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="168.388096" xlink:href="#m738a896821" y="171.910352"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="168.388096" xlink:href="#m738a896821" y="48.414082"/>
+    </g>
+   </g>
+   <g id="line2d_31">
+    <path clip-path="url(#p51484aca56)" d="M 199.581548 124.345514 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_32">
+    <path clip-path="url(#p51484aca56)" d="M 199.581548 174.153176 
+L 199.581548 74.537852 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_6">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="199.581548" xlink:href="#m738a896821" y="174.153176"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="199.581548" xlink:href="#m738a896821" y="74.537852"/>
+    </g>
+   </g>
+   <g id="line2d_33">
+    <path clip-path="url(#p51484aca56)" d="M 230.775 202.972964 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_34">
+    <path clip-path="url(#p51484aca56)" d="M 230.775 209.923014 
+L 230.775 196.022914 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_7">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="230.775" xlink:href="#m738a896821" y="209.923014"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="230.775" xlink:href="#m738a896821" y="196.022914"/>
+    </g>
+   </g>
+   <g id="line2d_35">
+    <path clip-path="url(#p51484aca56)" d="M 261.968452 73.613781 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_36">
+    <path clip-path="url(#p51484aca56)" d="M 261.968452 124.017351 
+L 261.968452 23.21021 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_8">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="261.968452" xlink:href="#m738a896821" y="124.017351"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="261.968452" xlink:href="#m738a896821" y="23.21021"/>
+    </g>
+   </g>
+   <g id="line2d_37">
+    <path clip-path="url(#p51484aca56)" d="M 293.161904 76.597164 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_38">
+    <path clip-path="url(#p51484aca56)" d="M 293.161904 143.050134 
+L 293.161904 10.144194 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_9">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="293.161904" xlink:href="#m738a896821" y="143.050134"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="293.161904" xlink:href="#m738a896821" y="10.144194"/>
+    </g>
+   </g>
+   <g id="line2d_39">
+    <path clip-path="url(#p51484aca56)" d="M 324.355356 160.417625 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_40">
+    <path clip-path="url(#p51484aca56)" d="M 324.355356 190.343681 
+L 324.355356 130.491569 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_10">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="324.355356" xlink:href="#m738a896821" y="190.343681"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="324.355356" xlink:href="#m738a896821" y="130.491569"/>
+    </g>
+   </g>
+   <g id="line2d_41">
+    <path clip-path="url(#p51484aca56)" d="M 355.548808 52.533505 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_42">
+    <path clip-path="url(#p51484aca56)" d="M 355.548808 88.15603 
+L 355.548808 16.910981 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_11">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="355.548808" xlink:href="#m738a896821" y="88.15603"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="355.548808" xlink:href="#m738a896821" y="16.910981"/>
+    </g>
+   </g>
+   <g id="line2d_43">
+    <path clip-path="url(#p51484aca56)" d="M 386.74226 204.684564 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_44">
+    <path clip-path="url(#p51484aca56)" d="M 386.74226 253.795806 
+L 386.74226 155.573323 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_12">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="386.74226" xlink:href="#m738a896821" y="253.795806"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="386.74226" xlink:href="#m738a896821" y="155.573323"/>
+    </g>
+   </g>
+   <g id="line2d_45">
+    <path clip-path="url(#p51484aca56)" d="M 417.935712 147.600656 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_46">
+    <path clip-path="url(#p51484aca56)" d="M 417.935712 157.331684 
+L 417.935712 137.869629 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_13">
+    <g clip-path="url(#p51484aca56)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="417.935712" xlink:href="#m738a896821" y="157.331684"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="417.935712" xlink:href="#m738a896821" y="137.869629"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p51484aca56">
+   <rect height="258.270709" width="396.780709" x="32.384646" y="2.834646"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/src/uncertain_datasets/uncertain_value_dataset.md
+++ b/docs/src/uncertain_datasets/uncertain_value_dataset.md
@@ -1,39 +1,46 @@
-`UncertainDataset`s have no explicit index associated with its uncertain values. This page shows how to construct such datasets.
+`UncertainValueDataset`s is an uncertain dataset type that has no explicit index 
+associated with its uncertain values. This type may come with some extra functionality 
+that the generic [UncertainDataset](uncertain_dataset.md) type does not support. 
 
-## Example 1
+Use this type when you want to be explicit about the values representing data values,
+as opposed to [indices](uncertain_index_dataset.md). 
+
+## Documentation
+
+```@docs
+UncertainValueDataset
+```
+
+## Examples
+
+### Example 1: constructing an `UncertainValueDataset` from uncertain values
 Let's create a random walk and pretend it represents fluctuations in the mean
 of an observed dataset. Assume that each data point is normally distributed,
 and that the $i$-th observation has standard deviation $\sigma_i \in [0.3, 0.5]$.
 
-Representing these data as an `UncertainDataset` is done as follows:
+Representing these data as an `UncertainValueDataset` is done as follows:
 
 ```julia 
-using UncertainData, Plots
+o1 = UncertainValue(Normal, 0, 0.5)
+o2 = UncertainValue(Normal, 2.0, 0.1)
+o3 = UncertainValue(Uniform, 0, 4)
+o4 = UncertainValue(Uniform, rand(100))
+o5 = UncertainValue(Beta, 4, 5)
+o6 = UncertainValue(Gamma, 4, 5)
+o7 = UncertainValue(Frechet, 1, 2)
+o8 = UncertainValue(BetaPrime, 1, 2)
+o9 = UncertainValue(BetaBinomial, 10, 3, 2)
+o10 = UncertainValue(Binomial, 10, 0.3)
 
-# Create a random walk of 55 steps
-n = 55
-rw = cumsum(rand(Normal(), n))
-
-# Represent each value of the random walk as an uncertain value and
-# collect them in an UncertainDataset
-dist = Uniform(0.3, 0.5)
-uncertainvals = [UncertainValue(Normal, rw[i], rand(dist)) for i = 1:n]
-D = UncertainDataset(uncertainvals)
+uvals = [o1, o2, o3, o4, o5, o6, o7, o8, o9, o10]
+d = UncertainValueDataset(uvals)
 ```
 
-By default, plotting the dataset will plot the median values (only for scatter plots) along with the 33rd to 67th
-percentile range error bars. 
+The built-in plot recipes makes it a breeze to plot the dataset. Here, we'll plot the 
+20th to 80th percentile range error bars. 
 
 ```
-plot(D)
+plot(d, [0.2, 0.8])
 ```
 
-![](uncertain_value_dataset_plot_defaulterrorbars.svg)
-
-You can customize the error bars by explicitly providing the quantiles:
-
-```
-plot(D, [0.05, 0.95])
-```
-
-![](uncertain_value_dataset_plot_customerrorbars.svg)
+![](uncertain_value_dataset_example.svg)

--- a/docs/src/uncertain_datasets/uncertain_value_dataset_example.svg
+++ b/docs/src/uncertain_datasets/uncertain_value_dataset_example.svg
@@ -1,0 +1,779 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Created with matplotlib (https://matplotlib.org/) -->
+<svg height="288pt" version="1.1" viewBox="0 0 432 288" width="432pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <style type="text/css">
+*{stroke-linecap:butt;stroke-linejoin:round;}
+  </style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 288 
+L 432 288 
+L 432 0 
+L 0 0 
+z
+" style="fill:#ffffff;"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 29.864646 261.105354 
+L 429.165354 261.105354 
+L 429.165354 2.834646 
+L 29.864646 2.834646 
+z
+" style="fill:#ffffff;"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path clip-path="url(#pd20c601622)" d="M 83.021029 261.105354 
+L 83.021029 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path d="M 0 0 
+L 0 -3.5 
+" id="mf074ff9a0c" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="83.021029" xlink:href="#mf074ff9a0c" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 2 -->
+      <defs>
+       <path d="M 19.1875 8.296875 
+L 53.609375 8.296875 
+L 53.609375 0 
+L 7.328125 0 
+L 7.328125 8.296875 
+Q 12.9375 14.109375 22.625 23.890625 
+Q 32.328125 33.6875 34.8125 36.53125 
+Q 39.546875 41.84375 41.421875 45.53125 
+Q 43.3125 49.21875 43.3125 52.78125 
+Q 43.3125 58.59375 39.234375 62.25 
+Q 35.15625 65.921875 28.609375 65.921875 
+Q 23.96875 65.921875 18.8125 64.3125 
+Q 13.671875 62.703125 7.8125 59.421875 
+L 7.8125 69.390625 
+Q 13.765625 71.78125 18.9375 73 
+Q 24.125 74.21875 28.421875 74.21875 
+Q 39.75 74.21875 46.484375 68.546875 
+Q 53.21875 62.890625 53.21875 53.421875 
+Q 53.21875 48.921875 51.53125 44.890625 
+Q 49.859375 40.875 45.40625 35.40625 
+Q 44.1875 33.984375 37.640625 27.21875 
+Q 31.109375 20.453125 19.1875 8.296875 
+z
+" id="DejaVuSans-50"/>
+      </defs>
+      <g transform="translate(80.476029 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-50"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path clip-path="url(#pd20c601622)" d="M 166.73187 261.105354 
+L 166.73187 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="166.73187" xlink:href="#mf074ff9a0c" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4 -->
+      <defs>
+       <path d="M 37.796875 64.3125 
+L 12.890625 25.390625 
+L 37.796875 25.390625 
+z
+M 35.203125 72.90625 
+L 47.609375 72.90625 
+L 47.609375 25.390625 
+L 58.015625 25.390625 
+L 58.015625 17.1875 
+L 47.609375 17.1875 
+L 47.609375 0 
+L 37.796875 0 
+L 37.796875 17.1875 
+L 4.890625 17.1875 
+L 4.890625 26.703125 
+z
+" id="DejaVuSans-52"/>
+      </defs>
+      <g transform="translate(164.18687 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-52"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path clip-path="url(#pd20c601622)" d="M 250.44271 261.105354 
+L 250.44271 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="250.44271" xlink:href="#mf074ff9a0c" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 6 -->
+      <defs>
+       <path d="M 33.015625 40.375 
+Q 26.375 40.375 22.484375 35.828125 
+Q 18.609375 31.296875 18.609375 23.390625 
+Q 18.609375 15.53125 22.484375 10.953125 
+Q 26.375 6.390625 33.015625 6.390625 
+Q 39.65625 6.390625 43.53125 10.953125 
+Q 47.40625 15.53125 47.40625 23.390625 
+Q 47.40625 31.296875 43.53125 35.828125 
+Q 39.65625 40.375 33.015625 40.375 
+z
+M 52.59375 71.296875 
+L 52.59375 62.3125 
+Q 48.875 64.0625 45.09375 64.984375 
+Q 41.3125 65.921875 37.59375 65.921875 
+Q 27.828125 65.921875 22.671875 59.328125 
+Q 17.53125 52.734375 16.796875 39.40625 
+Q 19.671875 43.65625 24.015625 45.921875 
+Q 28.375 48.1875 33.59375 48.1875 
+Q 44.578125 48.1875 50.953125 41.515625 
+Q 57.328125 34.859375 57.328125 23.390625 
+Q 57.328125 12.15625 50.6875 5.359375 
+Q 44.046875 -1.421875 33.015625 -1.421875 
+Q 20.359375 -1.421875 13.671875 8.265625 
+Q 6.984375 17.96875 6.984375 36.375 
+Q 6.984375 53.65625 15.1875 63.9375 
+Q 23.390625 74.21875 37.203125 74.21875 
+Q 40.921875 74.21875 44.703125 73.484375 
+Q 48.484375 72.75 52.59375 71.296875 
+z
+" id="DejaVuSans-54"/>
+      </defs>
+      <g transform="translate(247.89771 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-54"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path clip-path="url(#pd20c601622)" d="M 334.15355 261.105354 
+L 334.15355 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="334.15355" xlink:href="#mf074ff9a0c" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 8 -->
+      <defs>
+       <path d="M 31.78125 34.625 
+Q 24.75 34.625 20.71875 30.859375 
+Q 16.703125 27.09375 16.703125 20.515625 
+Q 16.703125 13.921875 20.71875 10.15625 
+Q 24.75 6.390625 31.78125 6.390625 
+Q 38.8125 6.390625 42.859375 10.171875 
+Q 46.921875 13.96875 46.921875 20.515625 
+Q 46.921875 27.09375 42.890625 30.859375 
+Q 38.875 34.625 31.78125 34.625 
+z
+M 21.921875 38.8125 
+Q 15.578125 40.375 12.03125 44.71875 
+Q 8.5 49.078125 8.5 55.328125 
+Q 8.5 64.0625 14.71875 69.140625 
+Q 20.953125 74.21875 31.78125 74.21875 
+Q 42.671875 74.21875 48.875 69.140625 
+Q 55.078125 64.0625 55.078125 55.328125 
+Q 55.078125 49.078125 51.53125 44.71875 
+Q 48 40.375 41.703125 38.8125 
+Q 48.828125 37.15625 52.796875 32.3125 
+Q 56.78125 27.484375 56.78125 20.515625 
+Q 56.78125 9.90625 50.3125 4.234375 
+Q 43.84375 -1.421875 31.78125 -1.421875 
+Q 19.734375 -1.421875 13.25 4.234375 
+Q 6.78125 9.90625 6.78125 20.515625 
+Q 6.78125 27.484375 10.78125 32.3125 
+Q 14.796875 37.15625 21.921875 38.8125 
+z
+M 18.3125 54.390625 
+Q 18.3125 48.734375 21.84375 45.5625 
+Q 25.390625 42.390625 31.78125 42.390625 
+Q 38.140625 42.390625 41.71875 45.5625 
+Q 45.3125 48.734375 45.3125 54.390625 
+Q 45.3125 60.0625 41.71875 63.234375 
+Q 38.140625 66.40625 31.78125 66.40625 
+Q 25.390625 66.40625 21.84375 63.234375 
+Q 18.3125 60.0625 18.3125 54.390625 
+z
+" id="DejaVuSans-56"/>
+      </defs>
+      <g transform="translate(331.60855 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-56"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path clip-path="url(#pd20c601622)" d="M 417.864391 261.105354 
+L 417.864391 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="417.864391" xlink:href="#mf074ff9a0c" y="261.105354"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 10 -->
+      <defs>
+       <path d="M 12.40625 8.296875 
+L 28.515625 8.296875 
+L 28.515625 63.921875 
+L 10.984375 60.40625 
+L 10.984375 69.390625 
+L 28.421875 72.90625 
+L 38.28125 72.90625 
+L 38.28125 8.296875 
+L 54.390625 8.296875 
+L 54.390625 0 
+L 12.40625 0 
+z
+" id="DejaVuSans-49"/>
+       <path d="M 31.78125 66.40625 
+Q 24.171875 66.40625 20.328125 58.90625 
+Q 16.5 51.421875 16.5 36.375 
+Q 16.5 21.390625 20.328125 13.890625 
+Q 24.171875 6.390625 31.78125 6.390625 
+Q 39.453125 6.390625 43.28125 13.890625 
+Q 47.125 21.390625 47.125 36.375 
+Q 47.125 51.421875 43.28125 58.90625 
+Q 39.453125 66.40625 31.78125 66.40625 
+z
+M 31.78125 74.21875 
+Q 44.046875 74.21875 50.515625 64.515625 
+Q 56.984375 54.828125 56.984375 36.375 
+Q 56.984375 17.96875 50.515625 8.265625 
+Q 44.046875 -1.421875 31.78125 -1.421875 
+Q 19.53125 -1.421875 13.0625 8.265625 
+Q 6.59375 17.96875 6.59375 36.375 
+Q 6.59375 54.828125 13.0625 64.515625 
+Q 19.53125 74.21875 31.78125 74.21875 
+z
+" id="DejaVuSans-48"/>
+      </defs>
+      <g transform="translate(412.774391 270.684104)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- Index -->
+     <defs>
+      <path d="M 9.8125 72.90625 
+L 19.671875 72.90625 
+L 19.671875 0 
+L 9.8125 0 
+z
+" id="DejaVuSans-73"/>
+      <path d="M 54.890625 33.015625 
+L 54.890625 0 
+L 45.90625 0 
+L 45.90625 32.71875 
+Q 45.90625 40.484375 42.875 44.328125 
+Q 39.84375 48.1875 33.796875 48.1875 
+Q 26.515625 48.1875 22.3125 43.546875 
+Q 18.109375 38.921875 18.109375 30.90625 
+L 18.109375 0 
+L 9.078125 0 
+L 9.078125 54.6875 
+L 18.109375 54.6875 
+L 18.109375 46.1875 
+Q 21.34375 51.125 25.703125 53.5625 
+Q 30.078125 56 35.796875 56 
+Q 45.21875 56 50.046875 50.171875 
+Q 54.890625 44.34375 54.890625 33.015625 
+z
+" id="DejaVuSans-110"/>
+      <path d="M 45.40625 46.390625 
+L 45.40625 75.984375 
+L 54.390625 75.984375 
+L 54.390625 0 
+L 45.40625 0 
+L 45.40625 8.203125 
+Q 42.578125 3.328125 38.25 0.953125 
+Q 33.9375 -1.421875 27.875 -1.421875 
+Q 17.96875 -1.421875 11.734375 6.484375 
+Q 5.515625 14.40625 5.515625 27.296875 
+Q 5.515625 40.1875 11.734375 48.09375 
+Q 17.96875 56 27.875 56 
+Q 33.9375 56 38.25 53.625 
+Q 42.578125 51.265625 45.40625 46.390625 
+z
+M 14.796875 27.296875 
+Q 14.796875 17.390625 18.875 11.75 
+Q 22.953125 6.109375 30.078125 6.109375 
+Q 37.203125 6.109375 41.296875 11.75 
+Q 45.40625 17.390625 45.40625 27.296875 
+Q 45.40625 37.203125 41.296875 42.84375 
+Q 37.203125 48.484375 30.078125 48.484375 
+Q 22.953125 48.484375 18.875 42.84375 
+Q 14.796875 37.203125 14.796875 27.296875 
+z
+" id="DejaVuSans-100"/>
+      <path d="M 56.203125 29.59375 
+L 56.203125 25.203125 
+L 14.890625 25.203125 
+Q 15.484375 15.921875 20.484375 11.0625 
+Q 25.484375 6.203125 34.421875 6.203125 
+Q 39.59375 6.203125 44.453125 7.46875 
+Q 49.3125 8.734375 54.109375 11.28125 
+L 54.109375 2.78125 
+Q 49.265625 0.734375 44.1875 -0.34375 
+Q 39.109375 -1.421875 33.890625 -1.421875 
+Q 20.796875 -1.421875 13.15625 6.1875 
+Q 5.515625 13.8125 5.515625 26.8125 
+Q 5.515625 40.234375 12.765625 48.109375 
+Q 20.015625 56 32.328125 56 
+Q 43.359375 56 49.78125 48.890625 
+Q 56.203125 41.796875 56.203125 29.59375 
+z
+M 47.21875 32.234375 
+Q 47.125 39.59375 43.09375 43.984375 
+Q 39.0625 48.390625 32.421875 48.390625 
+Q 24.90625 48.390625 20.390625 44.140625 
+Q 15.875 39.890625 15.1875 32.171875 
+z
+" id="DejaVuSans-101"/>
+      <path d="M 54.890625 54.6875 
+L 35.109375 28.078125 
+L 55.90625 0 
+L 45.3125 0 
+L 29.390625 21.484375 
+L 13.484375 0 
+L 2.875 0 
+L 24.125 28.609375 
+L 4.6875 54.6875 
+L 15.28125 54.6875 
+L 29.78125 35.203125 
+L 44.28125 54.6875 
+z
+" id="DejaVuSans-120"/>
+     </defs>
+     <g transform="translate(214.276562 284.706136)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use x="29.492188" xlink:href="#DejaVuSans-110"/>
+      <use x="92.871094" xlink:href="#DejaVuSans-100"/>
+      <use x="156.347656" xlink:href="#DejaVuSans-101"/>
+      <use x="217.855469" xlink:href="#DejaVuSans-120"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path clip-path="url(#pd20c601622)" d="M 29.864646 250.13346 
+L 429.165354 250.13346 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path d="M 0 0 
+L 3.5 0 
+" id="mf555beb40a" style="stroke:#000000;stroke-width:0.8;"/>
+      </defs>
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="29.864646" xlink:href="#mf555beb40a" y="250.13346"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0 -->
+      <g transform="translate(21.274646 253.172835)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path clip-path="url(#pd20c601622)" d="M 29.864646 206.618088 
+L 429.165354 206.618088 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="29.864646" xlink:href="#mf555beb40a" y="206.618088"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 5 -->
+      <defs>
+       <path d="M 10.796875 72.90625 
+L 49.515625 72.90625 
+L 49.515625 64.59375 
+L 19.828125 64.59375 
+L 19.828125 46.734375 
+Q 21.96875 47.46875 24.109375 47.828125 
+Q 26.265625 48.1875 28.421875 48.1875 
+Q 40.625 48.1875 47.75 41.5 
+Q 54.890625 34.8125 54.890625 23.390625 
+Q 54.890625 11.625 47.5625 5.09375 
+Q 40.234375 -1.421875 26.90625 -1.421875 
+Q 22.3125 -1.421875 17.546875 -0.640625 
+Q 12.796875 0.140625 7.71875 1.703125 
+L 7.71875 11.625 
+Q 12.109375 9.234375 16.796875 8.0625 
+Q 21.484375 6.890625 26.703125 6.890625 
+Q 35.15625 6.890625 40.078125 11.328125 
+Q 45.015625 15.765625 45.015625 23.390625 
+Q 45.015625 31 40.078125 35.4375 
+Q 35.15625 39.890625 26.703125 39.890625 
+Q 22.75 39.890625 18.8125 39.015625 
+Q 14.890625 38.140625 10.796875 36.28125 
+z
+" id="DejaVuSans-53"/>
+      </defs>
+      <g transform="translate(21.274646 209.657463)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path clip-path="url(#pd20c601622)" d="M 29.864646 163.102716 
+L 429.165354 163.102716 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="29.864646" xlink:href="#mf555beb40a" y="163.102716"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 10 -->
+      <g transform="translate(16.184646 166.142091)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path clip-path="url(#pd20c601622)" d="M 29.864646 119.587344 
+L 429.165354 119.587344 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="29.864646" xlink:href="#mf555beb40a" y="119.587344"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 15 -->
+      <g transform="translate(16.184646 122.626719)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path clip-path="url(#pd20c601622)" d="M 29.864646 76.071972 
+L 429.165354 76.071972 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="29.864646" xlink:href="#mf555beb40a" y="76.071972"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 20 -->
+      <g transform="translate(16.184646 79.111347)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path clip-path="url(#pd20c601622)" d="M 29.864646 32.5566 
+L 429.165354 32.5566 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-opacity:0.1;stroke-width:0.5;"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="29.864646" xlink:href="#mf555beb40a" y="32.5566"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 25 -->
+      <g transform="translate(16.184646 35.595975)scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-53"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- Value -->
+     <defs>
+      <path d="M 28.609375 0 
+L 0.78125 72.90625 
+L 11.078125 72.90625 
+L 34.1875 11.53125 
+L 57.328125 72.90625 
+L 67.578125 72.90625 
+L 39.796875 0 
+z
+" id="DejaVuSans-86"/>
+      <path d="M 34.28125 27.484375 
+Q 23.390625 27.484375 19.1875 25 
+Q 14.984375 22.515625 14.984375 16.5 
+Q 14.984375 11.71875 18.140625 8.90625 
+Q 21.296875 6.109375 26.703125 6.109375 
+Q 34.1875 6.109375 38.703125 11.40625 
+Q 43.21875 16.703125 43.21875 25.484375 
+L 43.21875 27.484375 
+z
+M 52.203125 31.203125 
+L 52.203125 0 
+L 43.21875 0 
+L 43.21875 8.296875 
+Q 40.140625 3.328125 35.546875 0.953125 
+Q 30.953125 -1.421875 24.3125 -1.421875 
+Q 15.921875 -1.421875 10.953125 3.296875 
+Q 6 8.015625 6 15.921875 
+Q 6 25.140625 12.171875 29.828125 
+Q 18.359375 34.515625 30.609375 34.515625 
+L 43.21875 34.515625 
+L 43.21875 35.40625 
+Q 43.21875 41.609375 39.140625 45 
+Q 35.0625 48.390625 27.6875 48.390625 
+Q 23 48.390625 18.546875 47.265625 
+Q 14.109375 46.140625 10.015625 43.890625 
+L 10.015625 52.203125 
+Q 14.9375 54.109375 19.578125 55.046875 
+Q 24.21875 56 28.609375 56 
+Q 40.484375 56 46.34375 49.84375 
+Q 52.203125 43.703125 52.203125 31.203125 
+z
+" id="DejaVuSans-97"/>
+      <path d="M 9.421875 75.984375 
+L 18.40625 75.984375 
+L 18.40625 0 
+L 9.421875 0 
+z
+" id="DejaVuSans-108"/>
+      <path d="M 8.5 21.578125 
+L 8.5 54.6875 
+L 17.484375 54.6875 
+L 17.484375 21.921875 
+Q 17.484375 14.15625 20.5 10.265625 
+Q 23.53125 6.390625 29.59375 6.390625 
+Q 36.859375 6.390625 41.078125 11.03125 
+Q 45.3125 15.671875 45.3125 23.6875 
+L 45.3125 54.6875 
+L 54.296875 54.6875 
+L 54.296875 0 
+L 45.3125 0 
+L 45.3125 8.40625 
+Q 42.046875 3.421875 37.71875 1 
+Q 33.40625 -1.421875 27.6875 -1.421875 
+Q 18.265625 -1.421875 13.375 4.4375 
+Q 8.5 10.296875 8.5 21.578125 
+z
+M 31.109375 56 
+z
+" id="DejaVuSans-117"/>
+     </defs>
+     <g transform="translate(9.896989 147.494609)rotate(-90)scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-86"/>
+      <use x="68.298828" xlink:href="#DejaVuSans-97"/>
+      <use x="129.578125" xlink:href="#DejaVuSans-108"/>
+      <use x="157.361328" xlink:href="#DejaVuSans-117"/>
+      <use x="220.740234" xlink:href="#DejaVuSans-101"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_23">
+    <path clip-path="url(#pd20c601622)" d="M 41.165609 250.13346 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_24">
+    <path clip-path="url(#pd20c601622)" d="M 41.165609 253.795806 
+L 41.165609 246.471114 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path d="M 2 0 
+L -2 -0 
+" id="mc7228c61ce" style="stroke:#000000;stroke-width:1.5;"/>
+    </defs>
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="41.165609" xlink:href="#mc7228c61ce" y="253.795806"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="41.165609" xlink:href="#mc7228c61ce" y="246.471114"/>
+    </g>
+   </g>
+   <g id="line2d_25">
+    <path clip-path="url(#pd20c601622)" d="M 83.021029 232.727311 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_26">
+    <path clip-path="url(#pd20c601622)" d="M 83.021029 233.45978 
+L 83.021029 231.994842 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_2">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="83.021029" xlink:href="#mc7228c61ce" y="233.45978"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="83.021029" xlink:href="#mc7228c61ce" y="231.994842"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 29.864646 261.105354 
+L 29.864646 2.834646 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 29.864646 261.105354 
+L 429.165354 261.105354 
+" style="fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;"/>
+   </g>
+   <g id="line2d_27">
+    <path clip-path="url(#pd20c601622)" d="M 124.87645 232.727311 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_28">
+    <path clip-path="url(#pd20c601622)" d="M 124.87645 243.171 
+L 124.87645 222.283622 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_3">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="124.87645" xlink:href="#mc7228c61ce" y="243.171"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="124.87645" xlink:href="#mc7228c61ce" y="222.283622"/>
+    </g>
+   </g>
+   <g id="line2d_29">
+    <path clip-path="url(#pd20c601622)" d="M 166.73187 245.852779 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_30">
+    <path clip-path="url(#pd20c601622)" d="M 166.73187 248.400867 
+L 166.73187 243.304692 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_4">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="166.73187" xlink:href="#mc7228c61ce" y="248.400867"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="166.73187" xlink:href="#mc7228c61ce" y="243.304692"/>
+    </g>
+   </g>
+   <g id="line2d_31">
+    <path clip-path="url(#pd20c601622)" d="M 208.58729 246.302756 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_32">
+    <path clip-path="url(#pd20c601622)" d="M 208.58729 247.494463 
+L 208.58729 245.053864 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_5">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="208.58729" xlink:href="#mc7228c61ce" y="247.494463"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="208.58729" xlink:href="#mc7228c61ce" y="245.053864"/>
+    </g>
+   </g>
+   <g id="line2d_33">
+    <path clip-path="url(#pd20c601622)" d="M 250.44271 90.34237 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_34">
+    <path clip-path="url(#pd20c601622)" d="M 250.44271 150.187928 
+L 250.44271 10.144194 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_6">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="250.44271" xlink:href="#mc7228c61ce" y="150.187928"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="250.44271" xlink:href="#mc7228c61ce" y="10.144194"/>
+    </g>
+   </g>
+   <g id="line2d_35">
+    <path clip-path="url(#pd20c601622)" d="M 292.29813 225.021695 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_36">
+    <path clip-path="url(#pd20c601622)" d="M 292.29813 239.318412 
+L 292.29813 172.129194 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_7">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="292.29813" xlink:href="#mc7228c61ce" y="239.318412"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="292.29813" xlink:href="#mc7228c61ce" y="172.129194"/>
+    </g>
+   </g>
+   <g id="line2d_37">
+    <path clip-path="url(#pd20c601622)" d="M 334.15355 246.528528 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_38">
+    <path clip-path="url(#pd20c601622)" d="M 334.15355 249.106201 
+L 334.15355 239.375868 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_8">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="334.15355" xlink:href="#mc7228c61ce" y="249.106201"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="334.15355" xlink:href="#mc7228c61ce" y="239.375868"/>
+    </g>
+   </g>
+   <g id="line2d_39">
+    <path clip-path="url(#pd20c601622)" d="M 376.008971 197.915013 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_40">
+    <path clip-path="url(#pd20c601622)" d="M 376.008971 215.321162 
+L 376.008971 180.508865 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_9">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="376.008971" xlink:href="#mc7228c61ce" y="215.321162"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="376.008971" xlink:href="#mc7228c61ce" y="180.508865"/>
+    </g>
+   </g>
+   <g id="line2d_41">
+    <path clip-path="url(#pd20c601622)" d="M 417.864391 224.024237 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="line2d_42">
+    <path clip-path="url(#pd20c601622)" d="M 417.864391 232.727311 
+L 417.864391 215.321162 
+" style="fill:none;stroke:#000000;stroke-linecap:round;"/>
+   </g>
+   <g id="PathCollection_10">
+    <g clip-path="url(#pd20c601622)">
+     <use style="stroke:#000000;stroke-width:1.5;" x="417.864391" xlink:href="#mc7228c61ce" y="232.727311"/>
+     <use style="stroke:#000000;stroke-width:1.5;" x="417.864391" xlink:href="#mc7228c61ce" y="215.321162"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd20c601622">
+   <rect height="258.270709" width="399.300709" x="29.864646" y="2.834646"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/src/uncertain_values/uncertainvalues_examples.md
+++ b/docs/src/uncertain_values/uncertainvalues_examples.md
@@ -1,13 +1,4 @@
-The core concept of `UncertainData` is to replace an uncertain data value with a 
-probability distribution describing the point's uncertainty.
 
-
-There are currently three ways of doing that: by [theoretical distributions](uncertainvalues_theoreticaldistributions.md),
-[theoretical distributions with parameters fitted to empirical data](uncertainvalues_fitted.md), or
-[kernel density estimations to the distributions of empirical data](uncertainvalued_kde.md). Check out the examples below
-and the documentation in the sidebar!
-
-### Uncertain values defined by theoretical distributions
 
 First, load the necessary packages:
 
@@ -15,10 +6,20 @@ First, load the necessary packages:
 using UncertainData, Distributions, KernelDensity, Plots
 ```
 
-#### A uniformly distributed uncertain value
-Now, consider the following trivial example. We've measure a data value with a poor instrument that tells us that the value lies between `-2` and `3`. However, we but that we know nothing more about how the value is distributed on that interval. Then it may be reasonable to represent that value as a uniform distribution on `[-2, 3]`.
+### Example 1: Uncertain values defined by theoretical distributions
 
-Define the uncertain value:
+#### A uniformly distributed uncertain value
+Consider the following contrived example. We've measure a data value with a poor instrument 
+that tells us that the value lies between `-2` and `3`. However, we but that we know nothing 
+more about how the value is distributed on that interval. Then it may be reasonable to 
+represent that value as a uniform distribution on `[-2, 3]`.
+
+To construct an uncertain value following a uniform distribution, we use the constructor 
+for theoretical distributions with known parameters 
+(`UncertainValue(distribution, params...)`). 
+
+The uniform distribution is defined by its lower and upper bounds, so we'll provide 
+these bounds as the parameters. 
 
 ```julia
 u = UncertainValue(Uniform, 1, 2)
@@ -33,8 +34,13 @@ bar(u, label = "", xlabel = "value", ylabel = "probability density")
 
 #### A normally distributed uncertain value
 
-Another common example is to use someone else's data from a publication. Usually, these values are reported as the mean or median, with some associated uncertainty. Say we want to use an uncertain value which is normally distributed with mean `2.1` and standard deviation `0.3`.
+A situation commonly encountered is to want to use someone else's data from a publication. 
+Usually, these values are reported as the mean or median, with some associated uncertainty. 
+Say we want to use an uncertain value which is normally distributed with mean `2.1` and 
+standard deviation `0.3`.
 
+Normal distributions also have two parameters, so we'll use the two-parameter constructor 
+as we did above. 
 
 ```julia
 u = UncertainValue(Normal, 2.1, 0.3)
@@ -46,43 +52,76 @@ bar(u, label = "", xlabel = "value", ylabel = "probability density")
 
 ![](uncertainvalue_theoretical_normal.svg)
 
+#### Other distributions 
 
-### Uncertain values defined by kernel density estimated distributions
+You may define uncertain values following any of the 
+[supported distributions](uncertainvalues_theoreticaldistributions.md). 
 
-One may also be given a a distribution of numbers that's not quite normally distributed. How to represent this uncertainty? Easy: we use a kernel density estimate to the distribution.
 
-In the following example, we generate some random numbers from a mixture of two normal distributions.
+### Example 2: Uncertain values defined by kernel density estimated distributions
 
+One may also be given a a distribution of numbers that's not quite normally distributed. 
+How to represent this uncertainty? Easy: we use a kernel density estimate to the distribution.
+
+Let's define a complicated distribution which is a mixture of two different normal 
+distributions, then draw a sample of numbers from it.
 
 ```julia
 M = MixtureModel([Normal(-5, 0.5), Normal(0.2)])
-u = UncertainValue(UnivariateKDE, rand(M, 250))
+some_sample = rand(M, 250)
+```
 
+Now, pretend that `some_sample` is a list of measurements we got from somewhere. 
+KDE estimates to the distribution can be defined implicitly or explicitly as follows:
+
+```julia 
+# If the only argument to `UncertainValue()` is a vector of number, KDE will be triggered.
+u = UncertainValue(rand(M, 250)) 
+
+# You may also tell the constructor explicitly that you want KDE. 
+u = UncertainValue(UnivariateKDE, rand(M, 250))
+```
+
+Now, let's plot the resulting distribution. _Note: this is not the original mixture of 
+Gaussians we started out with, it's the kernel density estimate to that mixture!_
+
+```julia 
 # Plot the estimated distribution.
 plot(u, xlabel = "Value", ylabel = "Probability density")
 ```
 
-
 ![](uncertainvalue_kde_bimodal.svg)
 
 
-### Uncertain values defined by theoretical distributions fitted to empirical data
+### Example 3: Uncertain values defined by theoretical distributions fitted to empirical data
 
 One may also be given a dataset whose histogram looks a lot like a theoretical
 distribution. We may then select a theoretical distribution and fit its
-parameters to the empirical data.
+parameters to the empirical data. 
 
-In the example below, we [resample](../resampling/resampling_uncertain_values.md)
-the estimated distribution to obtain a histogram we can compare to the original
-data.
+Say our data was a sample that looks like it obeys Gamma distribution. 
+
+```julia 
+# Draw a 2000-point sample from a Gamma distribution with parameters α = 1.7 and θ = 5.5
+some_sample = rand(Gamma(1.7, 5.5), 2000)
+```
+
+To perform a parameter estimation, simply provide the distribution as the first 
+argument and the sample as the second argument to the `UncertainValue` constructor.
 
 ```julia
-# Take a sample from a Gamma distribution with parameters α = 1.7 and θ = 5.5
+# Take a sample from a Gamma distribution with parameters α = 1.7 and θ = 5.5 and 
+# create a histogram of the sample.
 some_sample = rand(Gamma(1.7, 5.5), 2000)
-uv = UncertainValue(Gamma, some_sample)
+
 p1 = histogram(some_sample, normalize = true,
     fc = :black, lc = :black,
     label = "", xlabel = "value", ylabel = "density")
+
+# For the uncertain value representation, fit a gamma distribution to the sample. 
+# Then, compare the histogram obtained from the original distribution to that obtained 
+# when resampling the fitted distribution 
+uv = UncertainValue(Gamma, some_sample)
 
 # Resample the fitted theoretical distribution
 p2 = histogram(resample(uv, 10000), normalize = true,

--- a/docs/src/uncertain_values/uncertainvalues_fitted.md
+++ b/docs/src/uncertain_values/uncertainvalues_fitted.md
@@ -4,6 +4,13 @@ values. This will only work well if the histogram closely resembles a
 theoretical distribution.
 
 
+## Constructor
+
+```@docs
+UncertainValue(d::Type{D}, empiricaldata::Vector{T}) where {D<:Distribution, T}
+```
+
+
 ## Examples
 
 ``` julia tab="Uniform"
@@ -48,7 +55,7 @@ In real applications, make sure to always visually investigate the histogram
 of your data!
 
 
-## Beware: fitting distributions may lead to nonsensical results!
+### Beware: fitting distributions may lead to nonsensical results!
 In a less contrived example, we may try to fit a beta distribution to a sample
 generated from a gamma distribution.
 
@@ -71,10 +78,3 @@ try to fit a distribution that does not match your data.
 If the data do not follow an obvious theoretical distribution, it is better to
 use kernel density estimation to define the uncertain value.
 
-
-## Constructor
-
-
-```@docs
-UncertainValue(d::Type{D}, empiricaldata::Vector{T}) where {D<:Distribution, T}
-```

--- a/docs/src/uncertain_values/uncertainvalues_overview.md
+++ b/docs/src/uncertain_values/uncertainvalues_overview.md
@@ -1,11 +1,19 @@
-Uncertain values may be constructed in three different ways, depending on what
-information you have available. You may represent an uncertain value by
+The core concept of `UncertainData` is to replace an uncertain data value with a 
+probability distribution describing the point's uncertainty.
 
-- [theoretical distributions with known parameters](uncertainvalues_theoreticaldistributions.md)
-- [theoretical distributions with parameters fitted to empirical data](uncertainvalues_fitted.md)
-- [kernel density estimates to empirical data](uncertainvalues_kde.md)
+There are currently three ways of doing so:
 
-## Examples
+- by [theoretical distributions with known parameters](uncertainvalues_theoreticaldistributions.md)
+- by [theoretical distributions with parameters fitted to empirical data](uncertainvalues_fitted.md)
+- by [kernel density estimates to empirical data](uncertainvalues_kde.md)
+
+
+## Some quick examples
+
+See also the [extended examples](uncertainvalues_examples.md)!
+
+
+### Kernel density estimation (KDE)
 
 If the data doesn't follow an obvious theoretical distribution, the recommended
 course of action is to represent the uncertain value with a kernel density
@@ -31,10 +39,11 @@ using Distributions, UncertainData
 some_sample = rand(Normal(), 1000)
 
 
-
 # Specify that we want a kernel density estimate representation
 uv = UncertainValue(UnivariateKDE, some_sample)
 ```
+
+### Fitting a theoretical distribution
 
 If your data has a histogram closely resembling some theoretical distribution,
 the uncertain value may be represented by fitting such a distribution to the data.
@@ -62,6 +71,8 @@ some_sample = rand(Gamma(), 1000)
 # parameters fitted to the data.
 uv = UncertainValue(Gamma, some_sample)
 ```
+
+### Theoretical distribution with known parameters
 
 It is common when working with uncertain data found in the scientific
 literature that data value are stated to follow a distribution with given

--- a/docs/src/uncertain_values/uncertainvalues_theoreticaldistributions.md
+++ b/docs/src/uncertain_values/uncertainvalues_theoreticaldistributions.md
@@ -12,6 +12,34 @@ Supported distributions are `Uniform`, `Normal`, `Gamma`, `Beta`, `BetaPrime`,
 future!).
 
 
+
+## Constructors
+
+There are two constructors that creates uncertain values
+represented by theoretical distributions. Parameters are provided
+to the constructor in the same order as for constructing the equivalent
+distributions in `Distributions.jl`.
+
+Uncertain values represented by theoretical distributions may be constructed
+using the two-parameter or three-parameter constructors
+`UncertainValue(d::Type{D}, a<:Number, b<:Number)` or
+`UncertainValue(d::Type{D}, a<:Number, b<:Number, c<:Number)` (see below).
+
+
+### Two-parameter distributions
+
+```@docs
+UncertainValue(distribution::Type{D}, a::T1, b::T2; kwargs...) where {T1<:Number, T2 <: Number, D<:Distribution}
+```
+
+
+### Three-parameter distributions
+
+```@docs
+UncertainValue(distribution::Type{D}, a::T1, b::T2, c::T3; kwargs...) where {T1<:Number, T2<:Number, T3<:Number, D<:Distribution}
+```
+
+
 ## Examples
 
 ``` julia tab="Uniform"
@@ -61,29 +89,3 @@ uv = UncertainValue(Binomial, 28, 0.2)
 uv = UncertainValue(BetaBinomial, 28, 3.3, 4.4)
 ```
 
-
-## Constructors
-
-There are two constructors that creates uncertain values
-represented by theoretical distributions. Parameters are provided
-to the constructor in the same order as for constructing the equivalent
-distributions in `Distributions.jl`.
-
-Uncertain values represented by theoretical distributions may be constructed
-using the two-parameter or three-parameter constructors
-`UncertainValue(d::Type{D}, a<:Number, b<:Number)` or
-`UncertainValue(d::Type{D}, a<:Number, b<:Number, c<:Number)` (see below).
-
-
-### Two-parameter distributions
-
-```@docs
-UncertainValue(distribution::Type{D}, a::T1, b::T2; kwargs...) where {T1<:Number, T2 <: Number, D<:Distribution}
-```
-
-
-### Three-parameter distributions
-
-```@docs
-UncertainValue(distribution::Type{D}, a::T1, b::T2, c::T3; kwargs...) where {T1<:Number, T2<:Number, T3<:Number, D<:Distribution}
-```

--- a/src/mathematics/trig_functions_uncertainvalues.jl
+++ b/src/mathematics/trig_functions_uncertainvalues.jl
@@ -170,16 +170,72 @@ radians. Computes the element-wise `sincos` for `n` realizations.
 """ 
 Base.sincos(x::AbstractUncertainValue, n::Int) = sincos.(resample(x, n))
 
+""" 
+    Base.sinc(x::AbstractUncertainValue; n::Int = 10000)
+
+In an element-wise manner for `n` realizations of the uncertain value `x`, compute 
+``\\sin(\\pi x) / (\\pi x)`` if ``x \\neq 0``, and ``1`` if ``x = 0``.
+""" 
 Base.sinc(x::AbstractUncertainValue; n::Int = 10000) = sinc.(resample(x, n))
+
+""" 
+    Base.sinc(x::AbstractUncertainValue, n::Int = 10000)
+
+Compute ``\\sin(\\pi x) / (\\pi x)`` if ``x \\neq 0``, and ``1`` if ``x = 0`` element-wise 
+over `n` realizations of the uncertain value `x`. 
+""" 
 Base.sinc(x::AbstractUncertainValue, n::Int) = sinc.(resample(x, n))
 
+""" 
+    Base.sinpi(x::AbstractUncertainValue; n::Int = 10000)
+
+Compute ``\\sin(\\pi x)`` more accurately than `sin(pi*x)`, especially for large `x`, 
+in an element-wise over `n` realizations of the uncertain value `x`. 
+""" 
 Base.sinpi(x::AbstractUncertainValue; n::Int = 10000) = sinpi.(resample(x, n))
+
+""" 
+    Base.sinpi(x::AbstractUncertainValue; n::Int = 10000)
+
+Compute ``\\sin(\\pi x)`` more accurately than `sin(pi*x)`, especially for large `x`, 
+in an element-wise over `n` realizations of the uncertain value `x`. 
+""" 
 Base.sinpi(x::AbstractUncertainValue, n::Int) = sinpi.(resample(x, n))
 
+""" 
+    Base.cosc(x::AbstractUncertainValue; n::Int = 10000)
+
+Compute ``\\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2)`` if ``x \\neq 0``, and ``0`` if
+``x = 0``, in an element-wise manner over `n` realizations of the uncertain value `x`. 
+
+This is the derivative of `sinc(x)`.
+""" 
 Base.cosc(x::AbstractUncertainValue; n::Int = 10000) = cosc.(resample(x, n))
+
+""" 
+    Base.cosc(x::AbstractUncertainValue, n::Int = 10000)
+
+Compute ``\\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2)`` if ``x \\neq 0``, and ``0`` if
+``x = 0``, in an element-wise manner over `n` realizations of the uncertain value `x`. 
+
+This is the derivative of `sinc(x)`.
+""" 
 Base.cosc(x::AbstractUncertainValue, n::Int) = cosc.(resample(x, n))
 
+""" 
+    Base.cospi(x::AbstractUncertainValue; n::Int = 10000)
+
+Compute ``\\cos(\\pi x)`` more accurately than `cos(pi*x)`, especially for large `x`, 
+in an element-wise over `n` realizations of the uncertain value `x`. 
+""" 
 Base.cospi(x::AbstractUncertainValue; n::Int = 10000) = cospi.(resample(x, n))
+
+""" 
+    Base.cospi(x::AbstractUncertainValue, n::Int = 10000)
+
+Compute ``\\cos(\\pi x)`` more accurately than `cos(pi*x)`, especially for large `x`, 
+in an element-wise over `n` realizations of the uncertain value `x`. 
+""" 
 Base.cospi(x::AbstractUncertainValue, n::Int) = cospi.(resample(x, n))
 
 

--- a/src/uncertain_datasets/AbstractUncertainIndexDataset.jl
+++ b/src/uncertain_datasets/AbstractUncertainIndexDataset.jl
@@ -1,0 +1,3 @@
+include("AbstractUncertainValueDataset.jl")
+
+abstract type AbstractUncertainIndexDataset <: AbstractUncertainValueDataset end

--- a/src/uncertain_datasets/AbstractUncertainValueDataset.jl
+++ b/src/uncertain_datasets/AbstractUncertainValueDataset.jl
@@ -1,3 +1,4 @@
+import ..UncertainValues: minimum, maximum
 
 """
     AbstractUncertainValueDataset
@@ -20,18 +21,51 @@ end
 Base.show(io::IO, uvd::AbstractUncertainValueDataset) =
     println(io, summarise(uvd))
 
+##########################
+# Indexing and iteration
+#########################
 Base.getindex(uvd::AbstractUncertainValueDataset, i) = uvd.values[i]
-
 Base.length(uvd::AbstractUncertainValueDataset) = length(uvd.values)
 Base.size(uvd::AbstractUncertainValueDataset) = length(uvd)
 Base.firstindex(uvd::AbstractUncertainValueDataset) = 1
 Base.lastindex(uvd::AbstractUncertainValueDataset) = length(uvd.values)
 
+Base.eachindex(ud::AbstractUncertainValueDataset) = Base.OneTo(length(ud.values))
+Base.iterate(ud::AbstractUncertainValueDataset, state = 1) = iterate(ud.values, state)
 
-import ..UncertainValues: minimum, maximum
 
 Base.minimum(udata::AbstractUncertainValueDataset) = [minimum(uval) for uval in udata]
 Base.maximum(udata::AbstractUncertainValueDataset) = [maximum(uval) for uval in udata]
 
 
-export AbstractUncertainValueDataset
+
+
+###################
+# Pretty printing
+###################
+function summarise(ud::AbstractUncertainValueDataset)
+    _type = typeof(ud)
+    n_values = length(ud.values)
+    summary = "$_type with $n_values values"
+    return summary
+end
+
+Base.show(io::IO, ud::AbstractUncertainValueDataset) = print(io, summarise(ud))
+
+
+###################
+# Various useful functions
+###################
+"""
+    distributions(ud::UncertainDataset)
+
+Returns the distributions for all the uncertain values of the dataset.
+"""
+distributions(ud::AbstractUncertainValueDataset) = [ud[i].distribution for i = 1:length(ud)]
+
+
+
+
+export 
+AbstractUncertainValueDataset,
+distributions 

--- a/src/uncertain_datasets/UncertainDataset.jl
+++ b/src/uncertain_datasets/UncertainDataset.jl
@@ -1,7 +1,6 @@
 include("AbstractUncertainDataset.jl")
+include("AbstractUncertainValueDataset.jl")
 
-abstract type AbstractUncertainValueDataset <: AbstractUncertainDataset end
-abstract type AbstractUncertainIndexDataset <: AbstractUncertainDataset end
 
 """
     UncertainDataset
@@ -28,47 +27,8 @@ struct ConstrainedUncertainDataset{T <: AbstractUncertainValue} <: AbstractUncer
 end
 
 
-"""
-    UncertainIndices
-
-Generic dataset containing uncertain values.
-
-## Fields
-- **`values::AbstractVector{AbstractUncertainValue}`**: The uncertain values.
-"""
-struct UncertainIndices{T <: AbstractUncertainValue} <: AbstractUncertainIndexDataset
-    values::AbstractVector{T}
-end
-
-
-"""
-    ConstrainedUncertainIndices
-
-Generic constrained dataset containing uncertain values.
-
-## Fields
-- **`values::AbstractVector{AbstractUncertainValue}`**: The uncertain values.
-"""
-struct ConstrainedUncertainIndices{T <: AbstractUncertainValue} <: AbstractUncertainIndexDataset
-    values::AbstractVector{T}
-end
-
-
-
 UncertainDataset(uv::AbstractUncertainValue) = UncertainDataset([uv])
 ConstrainedUncertainDataset(uv::AbstractUncertainValue) = ConstrainedUncertainDataset([uv])
-
-##########################
-# Indexing and iteration
-#########################
-Base.getindex(ud::UncertainDataset, i) = ud.values[i]
-Base.length(ud::UncertainDataset) = length(ud.values)
-Base.size(ud::UncertainDataset) = length(ud)
-Base.firstindex(ud::UncertainDataset) = length(ud.values)
-Base.lastindex(ud::UncertainDataset) = length(ud.values)
-
-Base.eachindex(ud::UncertainDataset) = Base.OneTo(length(ud.values))
-Base.iterate(ud::UncertainDataset, state = 1) = iterate(ud.values, state)
 
 
 
@@ -76,31 +36,6 @@ Base.iterate(ud::UncertainDataset, state = 1) = iterate(ud.values, state)
 # Sorting
 #########################
 
-
-###################
-# Pretty printing
-###################
-function summarise(ud::UncertainDataset)
-    _type = typeof(ud)
-    n_values = length(ud.values)
-    summary = "$_type with $n_values values"
-    return summary
-end
-
-Base.show(io::IO, ud::UncertainDataset) = print(io, summarise(ud))
-
-"""
-    distributions(ud::UncertainDataset)
-
-Returns the distributions for all the uncertain values of the dataset.
-"""
-distributions(ud::UncertainDataset) = [ud[i].distribution for i = 1:length(ud)]
-
-
-
 export
 UncertainDataset,
-ConstrainedUncertainDataset,
-UncertainIndices,
-ConstrainedUncertainIndices,
-distributions
+ConstrainedUncertainDataset

--- a/src/uncertain_datasets/UncertainDatasets.jl
+++ b/src/uncertain_datasets/UncertainDatasets.jl
@@ -9,11 +9,28 @@ using Reexport
     using StaticArrays
     using Statistics
 
+    # The abstract type for all types of dataset holding uncertain values
     include("AbstractUncertainDataset.jl")
+
+    # An abstract type for uncertain datasets containing uncertain values yielding scalar 
+    # values when resampled. 
     include("AbstractUncertainValueDataset.jl")
-    include("AbstractUncertainIndexValueDataset.jl")
-    include("UncertainDataset.jl")
+
+    # One composite type for indices, another one for values. This distinction allows more 
+    # flexibility when applying sampling constraints (some constraints may be meaningful 
+    # only for indices, for example).
     include("UncertainValueDataset.jl")
+    include("UncertainIndexDataset.jl")
+
+      # A generic type with all the functionality of `AbstractUncertainValueDataset`, if you 
+    # can't be bothered with specifying 
+    include("UncertainDataset.jl")
+
+    # An abstract type for datasets containing both indices and data values.
+    include("AbstractUncertainIndexValueDataset.jl")
+
+    # A composite type with two fields: `indices` and `values`. Both fields may be 
+    # any subtype of AbstractUncertainValueDataset. 
     include("UncertainIndexValueDataset.jl")
 
 end # module

--- a/src/uncertain_datasets/UncertainIndexDataset.jl
+++ b/src/uncertain_datasets/UncertainIndexDataset.jl
@@ -1,0 +1,33 @@
+include("AbstractUncertainIndexDataset.jl")
+
+"""
+    UncertainIndices
+
+Generic dataset containing uncertain indices.
+
+## Fields
+- **`indices::AbstractVector{AbstractUncertainValue}`**: The uncertain values.
+"""
+struct UncertainIndexDataset <: AbstractUncertainIndexDataset
+    indices::AbstractVector{AbstractUncertainValue}
+end
+
+
+
+"""
+    ConstrainedUncertainIndexDataset
+
+Generic constrained dataset containing uncertain values.
+
+## Fields
+- **`indices::AbstractVector{AbstractUncertainValue}`**: The uncertain indices.
+"""
+struct ConstrainedUncertainIndexDataset <: AbstractUncertainIndexDataset
+    indices::AbstractVector{AbstractUncertainValue}
+end
+
+export 
+UncertainIndexDataset,
+ConstrainedUncertainIndexDataset,
+distributions
+

--- a/src/uncertain_datasets/UncertainIndexValueDataset.jl
+++ b/src/uncertain_datasets/UncertainIndexValueDataset.jl
@@ -7,14 +7,15 @@ depth, order, etc...) are also uncertain value.
 
 ## Fields
 
-- **`values::UncertainDataset`**: The uncertain indices. Each index is
-    represented by an `AbstractUncertainValue`.
+- **`values::T` where {T <: AbstractUncertainValueDataset}**: The uncertain indices. 
+    Will in general be an `UncertainIndexDataset`, but does not necessarily have to be.  
+    Each index is represented by an `AbstractUncertainValue`.
 - **`values::UncertainDataset`**: The uncertain values. Each value is
     represented by an `AbstractUncertainValue`.
 """
 struct UncertainIndexValueDataset <: AbstractUncertainIndexValueDataset
-    indices::UncertainDataset
-    values::UncertainDataset
+    indices::AbstractUncertainValueDataset
+    values::AbstractUncertainValueDataset
 end
 
 

--- a/src/uncertain_datasets/UncertainValueDataset.jl
+++ b/src/uncertain_datasets/UncertainValueDataset.jl
@@ -6,28 +6,26 @@ A dataset of uncertain values.
 
 ## Fields
 
-- **`values::UncertainDataset`**: The uncertain values. Each value is
+- **`values::AbstractVector{AbstractUncertainValue}`**: The uncertain values. Each value is
     represented by an `AbstractUncertainValue`.
 """
 struct UncertainValueDataset <: AbstractUncertainValueDataset
-    values::UncertainDataset
+    values::AbstractVector{AbstractUncertainValue}
 end
 
-Base.length(u::UncertainValueDataset) = length(u.values)
-Base.getindex(u::UncertainValueDataset, i) = u.values[i]
-Base.firstindex(u::UncertainValueDataset) = 1
-Base.lastindex(u::UncertainValueDataset) = length(u.values)
+"""
+    ConstrainedUncertainValueDataset
 
-Base.eachindex(u::UncertainValueDataset) = Base.OneTo(length(u))
-Base.iterate(u::UncertainValueDataset, state = 1) = iterate(u.values, state)
+Generic constrained dataset containing uncertain values.
 
-getvalues(u::UncertainValueDataset, i) = u.values
-getvalue(u::UncertainValueDataset, i) = u.values[i]
+## Fields
+- **`values::AbstractVector{AbstractUncertainValue}`**: The uncertain values.
+"""
+struct ConstrainedUncertainValueDataset{T <: AbstractUncertainValue} <: AbstractUncertainValueDataset
+    values::AbstractVector{T}
+end
 
-
-UncertainValueDataset(uv::AbstractUncertainValue) = UncertainValueDataset(UncertainDataset([uv]))
 
 export
 UncertainValueDataset,
-getvalue,
-getvalues
+ConstrainedUncertainValueDataset

--- a/test/resampling/test_resampling_datasets.jl
+++ b/test/resampling/test_resampling_datasets.jl
@@ -10,8 +10,9 @@ o8 = UncertainValue(BetaPrime, 1, 2)
 o9 = UncertainValue(BetaBinomial, 10, 3, 2)
 o10 = UncertainValue(Binomial, 10, 0.3)
 
-D = UncertainDataset([o1, o2, o3, o4, o5, o6, o7, o8, o9, o10])
-UV = UncertainValueDataset(D)
+uvals = [o1, o2, o3, o4, o5, o6, o7, o8, o9, o10]
+D = UncertainDataset(uvals)
+UV = UncertainValueDataset(uvals)
 UIV = UncertainIndexValueDataset(D, D)
 
 n = length(D)

--- a/test/sampling_constraints/test_constrain_uncertaindatasets.jl
+++ b/test/sampling_constraints/test_constrain_uncertaindatasets.jl
@@ -1,11 +1,14 @@
 import Distributions
 
+using Distributions, UncertainData 
+
 # Create an uncertain dataset containing both theoretical values with known parameters, 
 # theoretical values with fitted parameters and kernel density estimated distributions.
-measurements = [[UncertainValue(Normal, 0, 0.1) for i = 1:5]
-                UncertainValue(rand(500))]; 
-                #UncertainValue(Normal, rand(Normal(2, 0.35), 10000))]
+u1 = UncertainValue(Gamma, rand(Gamma(), 500))
+u2 = UncertainValue(rand(MixtureModel([Normal(1, 0.3), Normal(-3, 3)]), 500))
+uvals3 = [UncertainValue(Normal, rand(), rand()) for i = 1:11]
 
+measurements = [u1; u2; uvals3]
 d = UncertainDataset(measurements)
 
 # Test that constraining work for all available constraints, applying the same 

--- a/test/uncertain_datasets/test_uncertain_datasets.jl
+++ b/test/uncertain_datasets/test_uncertain_datasets.jl
@@ -25,7 +25,7 @@ D = UncertainDataset([o1, o2, o3])
 ########################
 
 # Construction
-UV = UncertainValueDataset(D)
+UV = UncertainValueDataset(D.values)
 @test UV isa UncertainValueDataset
 
 # Iteration


### PR DESCRIPTION
## UncertainData.jl v0.1.3

- Allow both the `indices` and `values` fields of `UncertainIndexValueDataset` to be any 
    subtype of `AbstractUncertainValueDataset`. This way, you don't **have** to use an 
    index dataset type for the indices if not necessary.
- Improved documentation for `UncertainIndexDataset`, `UncertainValueDataset`, 
    `UncertainDataset` and `UncertainIndexValueDataset` types and added an 
    [overview page](uncertain_datasets/uncertain_datasets_overview.md) in the documentation 
    to explain the difference between these types.
- Added an [overview](resampling/resampling_overview.md) section for the resampling 
    documentation.
- Cleaned and improved [documentation for uncertain values](uncertainvalues_overview.md). 
- Added separate [documentation for the uncertain index dataset type](uncertain_datasets/uncertain_index_dataset.md).
- Added separate [documentation for the uncertain value dataset type](uncertain_datasets/uncertain_value_dataset.md).
- Improved [documentation for the generic uncertain dataset type](uncertain_datasets/uncertain_dataset.md) 
- Merged documentation for sampling constraints and resampling.
- Added missing documentation for the `sinc`, `sincos`, `sinpi`, `cosc` and `cospi` trig 
    functions.