### PR TITLE
Fixed resampling of vectors of uncertain vals + added resample_elwise

### DIFF
--- a/src/resampling/Resampling.jl
+++ b/src/resampling/Resampling.jl
@@ -46,7 +46,7 @@ using Reexport
     #########################################
     include("resampling_with_interpolation/resample_linear_interpolation.jl")
 
-    export resample
+    export resample, resample_elwise
 end # module
 
 

--- a/src/resampling/uncertain_values/resample_uncertainvalues_vector_withconstraints.jl
+++ b/src/resampling/uncertain_values/resample_uncertainvalues_vector_withconstraints.jl
@@ -1,11 +1,11 @@
 
 """
-resample(uvals::Vector{AbstractUncertainValue})
+resample(uvals::Vector{AbstractUncertainValue}, c::SamplingConstrant)
 
-Treat `uvals` as a dataset and resample each value of `uvals` once. 
+Treat `uvals` as a dataset and resample each value of `uvals` once,
 Returns an `length(uvals)`-element vector.
 """
-resample(uvals::Vector{AbstractUncertainValue}) = resample.(uvals)
+resample(uvals::Vector{AbstractUncertainValue}, c::SamplingConstrant) = resample.(uvals, c)
 
 
 """
@@ -16,9 +16,8 @@ Returns `n` resampled draws of `uvals`, each being a `length(uvals)`-element vec
 For each returned vector, the i-th element is a unique draw of `uvals[i]`. 
 """
 function resample(uvals::Vector{AbstractUncertainValue}, n::Int) 
-    [resample.(uvals) for i = 1:n]
+[resample.(uvals) for i = 1:n]
 end
-
 
 """
 resample_elwise(uvals::Vector{AbstractUncertainValue}, n::Int) 

--- a/test/resampling/uncertain_vectors/test_resampling_vectors.jl
+++ b/test/resampling/uncertain_vectors/test_resampling_vectors.jl
@@ -1,0 +1,37 @@
+import KernelDensity.UnivariateKDE
+o1 = UncertainValue(Normal, 0, 0.5)
+o2 = UncertainValue(Normal, 2.0, 0.1)
+o3 = UncertainValue(Uniform, 0, 4)
+o4 = UncertainValue(Uniform, rand(100))
+o5 = UncertainValue(Beta, 4, 5)
+o6 = UncertainValue(Gamma, 4, 5)
+o7 = UncertainValue(Frechet, 1, 2)
+o8 = UncertainValue(BetaPrime, 1, 2)
+o9 = UncertainValue(BetaBinomial, 10, 3, 2)
+o10 = UncertainValue(Binomial, 10, 0.3)
+o11 = UncertainValue(rand(100), rand(100))
+o12 = UncertainValue(2)
+o13 = UncertainValue(2.3)
+o14 = UncertainValue([2, 3, 4], [0.3, 0.4, 0.3])
+o15 = UncertainValue([rand() for i = 1:100])
+
+
+uvals1 = [o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o15, o4, o5, 
+    o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, 
+    o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14]
+
+
+# resample(uvals::Vector{AbstractUncertainValue})
+@test resample(uvals1) isa Vector
+@test length(resample(uvals1)) == length(uvals1)
+
+# resample(uvals::Vector{AbstractUncertainValue}, n::Int) 
+n = 2
+@test resample(uvals1, n) isa Vector{Vector{T}} where T <: Real
+@test length(resample(uvals1, n)) == n
+
+# resample_elwise(uvals::Vector{AbstractUncertainValue}, n::Int) 
+n = 2
+@test resample_elwise(uvals1, n) isa Vector{Vector}
+@test length(resample_elwise(uvals1, n)) == length(uvals1)
+@test length(resample_elwise(uvals1, n)[1]) == n

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,8 @@ include("resampling/uncertain_values/test_resampling_certain_value.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues_kde.jl")
 
+include("resampling/uncertain_vectors/test_resampling_vectors.jl")
+
 include("resampling/uncertain_datasets/test_resampling_datasets.jl")
 include("resampling/uncertain_datasets/test_resampling_with_constraints.jl")
 include("resampling/uncertain_datasets/sequential/test_resampling_sequential_increasing.jl")


### PR DESCRIPTION
### New functionality and syntax changes 
- `resample(uvals::Vector{AbstractUncertainValue}, n::Int)` is now interpreted as "treat `uvals` as a dataset and sample it `n` times". Thus, it now behaves as `resample(AbstractUncertainDataset, n::Int)`, returning `n` vectors of length `length(uvals)`, where the i-th element is a unique draw of `uvals[i]`.
- `resample_elwise(uvals::Vector{AbstractUncertainValue}, n::Int)` takes over the role as "sample `uvals` element-wise and `n` times for each element". Returns a vector of length `length(uvals)`,
where the i-th element is a `n`-element vector of unique draws of `uvals[i]`.