### PR TITLE
Release 0.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "UncertainData"
 uuid = "dcd9ba68-c27b-5cea-ae21-829cd07325bf"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>"]
 repo = "https://github.com/kahaaga/UncertainData.jl.git"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Bootstrap = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -64,16 +64,15 @@ pages:
       - Uncertain index-value dataset: uncertain_datasets/uncertain_indexvalue_dataset.md
   - Resampling:
     - Overview: resampling/resampling_overview.md
-    - Constraints:
+    - Sampling constraints:
       - Constraining uncertain values: sampling_constraints/constrain_uncertain_values.md
       - Generic constraints: sampling_constraints/available_constraints.md
       - Sequential constraints:
         - List of sequential constraints: sampling_constraints/sequential_constraints.md
         - Existence of sequences: sampling_constraints/ordered_sequence_exists.md
-    - Resampling methods:
-      - Resampling uncertain values: resampling/resampling_uncertain_values.md
-      - Resampling uncertain value datasets: resampling/resampling_uncertain_datasets.md
-      - Resampling uncertain index-value datasets: resampling/resampling_uncertain_indexvalue_datasets.md
+    - Resampling uncertain values: resampling/resampling_uncertain_values.md
+    - Resampling uncertain datasets: resampling/resampling_uncertain_datasets.md
+    - Resampling uncertain index-value datasets: resampling/resampling_uncertain_indexvalue_datasets.md
     - Sequential resampling: 
       - Overview: resampling/sequential/resampling_uncertaindatasets_sequential.md
       - Strictly increasing: resampling/sequential/strictly_increasing.md

--- a/src/resampling/Resampling.jl
+++ b/src/resampling/Resampling.jl
@@ -46,7 +46,7 @@ using Reexport
     #########################################
     include("resampling_with_interpolation/resample_linear_interpolation.jl")
 
-    export resample
+    export resample, resample_elwise
 end # module
 
 

--- a/src/resampling/Resampling.jl
+++ b/src/resampling/Resampling.jl
@@ -2,7 +2,6 @@ using Reexport
 
 @reexport module Resampling
 
-    
     ###################################
     # Resampling uncertain values
     ###################################
@@ -27,9 +26,13 @@ using Reexport
     ###################################
     # Resampling uncertain datasets
     ###################################
+
+    # Supertype for all uncertain value datasets
+    include("uncertain_dataset/resample_abstractuncertainvaluedataset.jl")
+
+    # Specialized resampling for each type of dataset.
     include("uncertain_dataset/resample_uncertaindataset.jl")
 	include("uncertain_dataset/resample_uncertaindataset_withconstraint.jl")
-
     include("uncertain_dataset/resample_uncertaindataset_index.jl")
     include("uncertain_dataset/resample_uncertaindataset_value.jl")
     include("uncertain_dataset/resample_uncertaindataset_indexvalue.jl")

--- a/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
+++ b/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
@@ -5,6 +5,15 @@ import ..UncertainDatasets:
 import ..SamplingConstraints: 
     SamplingConstraint
 
+"""
+    resample_elwise(uvd::AbstractUncertainValueDataset)
+
+Resample each element in `uvals` once. The i-th entry in the returned 
+vector is a `1`-element vector containing one unique draw of `uvals[i]`.
+"""
+function resample_elwise(uvd::AbstractUncertainValueDataset)
+    [resample(uvd[i], 1) for i = 1:length(uvd)]
+end
 
 """
     resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
@@ -17,15 +26,33 @@ function resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
 end
 
 """
-    resample_elwise(uvd::AbstractUncertainValueDataset, constraint::SamplingConstraint, 
-        n::Int)
+    resample_elwise(uvd::AbstractUncertainValueDataset, 
+        constraint::SamplingConstraint, n::Int)
 
 Resample each element in `uvals` `n` times. The i-th entry in the returned 
 vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`, drawn 
-after first truncating the support of `uvals[i]` according to the provided `constraint`.
+after first truncating the support of `uvals[i]` according to the provided `constraint`(s).
 """
+resample_elwise(uvd::AbstractUncertainValueDataset, 
+    constraint::Union{SamplingConstraint, Vector{SamplingConstraint}}, n::Int)
+
+
 function resample_elwise(uvd::AbstractUncertainValueDataset, 
         constraint::SamplingConstraint, n::Int)
     
     [resample(uvd[i], constraint, n) for i = 1:length(uvd)]
+end
+
+
+function resample_elwise(uvd::AbstractUncertainValueDataset, 
+        constraint::Vector{<:SamplingConstraint}, 
+        n::Int)
+    
+    Lc, Luv = length(constraint), length(uvd)
+    
+    if Lc != Luv
+        error("""The number of constraints must match the number of uncertain values in the dataset. Got $Lc constraint but needed $Luv.""")
+    end
+    
+    [resample(uvd[i], constraint[i], n) for i = 1:length(uvd)]
 end

--- a/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
+++ b/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
@@ -1,0 +1,31 @@
+
+import ..UncertainDatasets:
+    AbstractUncertainValueDataset
+
+import ..SamplingConstraints: 
+    SamplingConstraint
+
+
+"""
+    resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`.
+"""
+function resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
+    [resample(uvd[i], n) for i = 1:length(uvd)]
+end
+
+"""
+    resample_elwise(uvd::AbstractUncertainValueDataset, constraint::SamplingConstraint, 
+        n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`, drawn 
+after first truncating the support of `uvals[i]` according to the provided `constraint`.
+"""
+function resample_elwise(uvd::AbstractUncertainValueDataset, 
+        constraint::SamplingConstraint, n::Int)
+    
+    [resample(uvd[i], constraint, n) for i = 1:length(uvd)]
+end

--- a/src/resampling/uncertain_dataset/resample_uncertaindataset_index.jl
+++ b/src/resampling/uncertain_dataset/resample_uncertaindataset_index.jl
@@ -12,7 +12,7 @@ function resample(uvd::UncertainIndexDataset)
 end
 
 """
-	resample(uvd::UncertainIndexDataset)
+	resample(uvd::UncertainIndexDataset, n::Int)
 
 Draw `n` realisations of an `UncertainIndexDataset` according to the
 distributions of the `UncertainValue`s comprising it.
@@ -22,6 +22,16 @@ function resample(uvd::UncertainIndexDataset, n::Int)
 	[[resample(uvd.indices[i]) for i in 1:L] for k in 1:n]
 end
 
+
+"""
+	resample_elwise(uvd::UncertainIndexDataset, n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`.
+"""
+function resample_elwise(uvd::UncertainIndexDataset, n::Int)
+    [resample(uvd[i], n) for i = 1:length(uvd)]
+end
 
 
 ##########################################################################
@@ -137,4 +147,15 @@ the supports of the distributions are truncated above at some quantile.
 function resample(uv::UncertainIndexDataset, constraint::TruncateQuantiles, n::Int)
 	L = length(uv)
 	[[resample(uv.indices[i], constraint) for i in 1:L] for k = 1:n]
+end
+
+"""
+    resample_elwise(uvd::UncertainIndexDataset, constraint::SamplingConstraint, n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`, drawn 
+after first truncating the support of `uvals[i]` according to the provided `constraint`.
+"""
+function resample_elwise(uvd::UncertainIndexDataset, constraint::SamplingConstraint, n::Int)
+    [resample(uvd[i], constraint, n) for i = 1:length(uvd)]
 end

--- a/src/resampling/uncertain_values/resample_uncertainvalues_vector_withconstraints.jl
+++ b/src/resampling/uncertain_values/resample_uncertainvalues_vector_withconstraints.jl
@@ -1,11 +1,11 @@
 
 """
-resample(uvals::Vector{AbstractUncertainValue})
+resample(uvals::Vector{AbstractUncertainValue}, c::SamplingConstrant)
 
-Treat `uvals` as a dataset and resample each value of `uvals` once. 
+Treat `uvals` as a dataset and resample each value of `uvals` once,
 Returns an `length(uvals)`-element vector.
 """
-resample(uvals::Vector{AbstractUncertainValue}) = resample.(uvals)
+resample(uvals::Vector{AbstractUncertainValue}, c::SamplingConstrant) = resample.(uvals, c)
 
 
 """
@@ -16,9 +16,8 @@ Returns `n` resampled draws of `uvals`, each being a `length(uvals)`-element vec
 For each returned vector, the i-th element is a unique draw of `uvals[i]`. 
 """
 function resample(uvals::Vector{AbstractUncertainValue}, n::Int) 
-    [resample.(uvals) for i = 1:n]
+[resample.(uvals) for i = 1:n]
 end
-
 
 """
 resample_elwise(uvals::Vector{AbstractUncertainValue}, n::Int) 

--- a/src/uncertain_values/Population.jl
+++ b/src/uncertain_values/Population.jl
@@ -27,7 +27,7 @@ function summarise(p::AbstractScalarPopulation)
     return summary
 end
 
-Base.show(io::IO, p::AbstractScalarPopulation) = println(io, summarise(p))
+Base.show(io::IO, p::AbstractScalarPopulation) = print(io, summarise(p))
 
 
 Base.rand(p::AbstractScalarPopulation) = sample(p.values, p.probs)

--- a/test/resampling/uncertain_datasets/test_resampling_elwise.jl
+++ b/test/resampling/uncertain_datasets/test_resampling_elwise.jl
@@ -44,6 +44,14 @@ n = 3
 @test length(resample_elwise(UVD, n)) == length(UVD)
 @test length(resample_elwise(UVD, n)[1]) == n
 
+n = 5
+@test length(resample_elwise(UD, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UD)], n)) == length(UD)
+@test length(resample_elwise(UD, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UD)], n)[1]) == n
+@test length(resample_elwise(UVD, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UVD)], n)) == length(UD)
+@test length(resample_elwise(UVD, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UVD)], n)[1]) == n
+@test length(resample_elwise(UIDX, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UIDX)], n)) == length(UD)
+@test length(resample_elwise(UIDX, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UIDX)], n)[1]) == n
+
 # resample_elwise(uvd::AbstractUncertainValueDataset, constraint::SamplingConstraint, n::Int)
 @test length(resample_elwise(UIDX, TruncateQuantiles(0.1, 0.9), n)) == length(UIDX)
 @test length(resample_elwise(UIDX, TruncateQuantiles(0.1, 0.9), n)[1]) == n

--- a/test/resampling/uncertain_datasets/test_resampling_elwise.jl
+++ b/test/resampling/uncertain_datasets/test_resampling_elwise.jl
@@ -44,6 +44,9 @@ n = 3
 @test length(resample_elwise(UVD, n)) == length(UVD)
 @test length(resample_elwise(UVD, n)[1]) == n
 
+@test length(resample_elwise(UVD)[1]) == 1
+@test length(resample_elwise(UVD)) == length(UVD)
+
 n = 5
 @test length(resample_elwise(UD, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UD)], n)) == length(UD)
 @test length(resample_elwise(UD, [TruncateQuantiles(0.1, 0.9) for i = 1:length(UD)], n)[1]) == n

--- a/test/resampling/uncertain_datasets/test_resampling_elwise.jl
+++ b/test/resampling/uncertain_datasets/test_resampling_elwise.jl
@@ -1,0 +1,53 @@
+# Define some example data 
+import KernelDensity.UnivariateKDE
+o1 = UncertainValue(Normal, 0, 0.5)
+o2 = UncertainValue(Normal, 2.0, 0.1)
+o3 = UncertainValue(Uniform, 0, 4)
+o4 = UncertainValue(Uniform, rand(100))
+o5 = UncertainValue(Beta, 4, 5)
+o6 = UncertainValue(Gamma, 4, 5)
+o7 = UncertainValue(Frechet, 1, 2)
+o8 = UncertainValue(BetaPrime, 1, 2)
+o9 = UncertainValue(BetaBinomial, 10, 3, 2)
+o10 = UncertainValue(Binomial, 10, 0.3)
+o11 = UncertainValue(rand(100), rand(100))
+o12 = UncertainValue(2)
+o13 = UncertainValue(2.3)
+o14 = UncertainValue([2, 3, 4], [0.3, 0.4, 0.3])
+o15 = UncertainValue([rand() for i = 1:100])
+
+
+uvals1 = [o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o15, o4, o5, 
+    o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, 
+    o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14]
+
+uvals2 = [uvals1[i] for i in [rand(1:length(uvals1)) for i = 1:length(uvals1)]]
+
+idxs = UncertainIndexDataset([UncertainValue(Normal, i, 0.8) for i = 1:length(uvals1)])
+
+UVD = UncertainValueDataset(uvals1)
+UD = UncertainDataset(uvals2)
+UIDX = UncertainIndexDataset(idxs)
+UV = UncertainValueDataset(uvals1)
+
+# Resampling interface should work for all subtypes of AbstractUncertainValueDataset,
+# both with and without sampling constraints.
+# We need to check UncertainDataset, UncertainIndexDataset, and UncertainValueDataset.
+
+n = 3
+
+#resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
+@test length(resample_elwise(UIDX, n)) == length(UIDX)
+@test length(resample_elwise(UIDX, n)[1]) == n
+@test length(resample_elwise(UD, n)) == length(UD)
+@test length(resample_elwise(UD, n)[1]) == n
+@test length(resample_elwise(UVD, n)) == length(UVD)
+@test length(resample_elwise(UVD, n)[1]) == n
+
+# resample_elwise(uvd::AbstractUncertainValueDataset, constraint::SamplingConstraint, n::Int)
+@test length(resample_elwise(UIDX, TruncateQuantiles(0.1, 0.9), n)) == length(UIDX)
+@test length(resample_elwise(UIDX, TruncateQuantiles(0.1, 0.9), n)[1]) == n
+@test length(resample_elwise(UD, TruncateQuantiles(0.1, 0.9), n)) == length(UD)
+@test length(resample_elwise(UD, TruncateQuantiles(0.1, 0.9), n)[1]) == n
+@test length(resample_elwise(UVD, TruncateQuantiles(0.1, 0.9), n)) == length(UVD)
+@test length(resample_elwise(UVD, TruncateQuantiles(0.1, 0.9), n)[1]) == n

--- a/test/resampling/uncertain_vectors/test_resampling_vectors.jl
+++ b/test/resampling/uncertain_vectors/test_resampling_vectors.jl
@@ -1,0 +1,37 @@
+import KernelDensity.UnivariateKDE
+o1 = UncertainValue(Normal, 0, 0.5)
+o2 = UncertainValue(Normal, 2.0, 0.1)
+o3 = UncertainValue(Uniform, 0, 4)
+o4 = UncertainValue(Uniform, rand(100))
+o5 = UncertainValue(Beta, 4, 5)
+o6 = UncertainValue(Gamma, 4, 5)
+o7 = UncertainValue(Frechet, 1, 2)
+o8 = UncertainValue(BetaPrime, 1, 2)
+o9 = UncertainValue(BetaBinomial, 10, 3, 2)
+o10 = UncertainValue(Binomial, 10, 0.3)
+o11 = UncertainValue(rand(100), rand(100))
+o12 = UncertainValue(2)
+o13 = UncertainValue(2.3)
+o14 = UncertainValue([2, 3, 4], [0.3, 0.4, 0.3])
+o15 = UncertainValue([rand() for i = 1:100])
+
+
+uvals1 = [o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o15, o4, o5, 
+    o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, 
+    o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14]
+
+
+# resample(uvals::Vector{AbstractUncertainValue})
+@test resample(uvals1) isa Vector
+@test length(resample(uvals1)) == length(uvals1)
+
+# resample(uvals::Vector{AbstractUncertainValue}, n::Int) 
+n = 2
+@test resample(uvals1, n) isa Vector{Vector{T}} where T <: Real
+@test length(resample(uvals1, n)) == n
+
+# resample_elwise(uvals::Vector{AbstractUncertainValue}, n::Int) 
+n = 2
+@test resample_elwise(uvals1, n) isa Vector{Vector}
+@test length(resample_elwise(uvals1, n)) == length(uvals1)
+@test length(resample_elwise(uvals1, n)[1]) == n

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,8 @@ include("resampling/uncertain_values/test_resampling_certain_value.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues_kde.jl")
 
+include("resampling/uncertain_vectors/test_resampling_vectors.jl")
+
 include("resampling/uncertain_datasets/test_resampling_datasets.jl")
 include("resampling/uncertain_datasets/test_resampling_with_constraints.jl")
 include("resampling/uncertain_datasets/sequential/test_resampling_sequential_increasing.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ include("resampling/uncertain_values/test_resampling_certain_value.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues_kde.jl")
 
+include("resampling/uncertain_datasets/test_resampling_elwise.jl")
 include("resampling/uncertain_vectors/test_resampling_vectors.jl")
 
 include("resampling/uncertain_datasets/test_resampling_datasets.jl")


### PR DESCRIPTION
### New functionality and syntax changes 
#### Resampling vectors consisting of uncertain values (done in #61)

- [x] `resample(uvals::Vector{AbstractUncertainValue}, n::Int)` is now interpreted as "treat `uvals` as a dataset and sample it `n` times". Thus, it now behaves as `resample(AbstractUncertainDataset, n::Int)`, returning `n` vectors of length `length(uvals)`, where the i-th element is a unique draw of `uvals[i]`.

- [x] `resample_elwise(uvals::Vector{AbstractUncertainValue}, n::Int)` takes over the role as "sample `uvals` element-wise and `n` times for each element". Returns a vector of length `length(uvals)`, where the i-th element is a `n`-element vector of unique draws of `uvals[i]`.

#### Resampling with subtypes of `AbstractUncertainValueDataset`

Currently, this affects the generic `UncertainDataset`s, as well as the specialized `UncertainIndexDataset`s and `UncertainValueDataset`s.

- [x] `resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)` is now interpreted as 
    "draw `n` realisations of each value in `uvd`". Returns a vector of length `length(uvals)` 
    where the i-th element is a `n`-element vector of unique draws of `uvals[i]`. This works 
    for `UncertainDataset`s, `UncertainIndexDataset`s, and `UncertainValueDataset`s. 
- [x] `resample_elwise(uvd::AbstractUncertainValueDataset, constraint::Union{SamplingConstraint, Vector{SamplingConstraint}}, n::Int)` 
    is now interpreted as "draw `n` realisations of each value in `uvd`, subjecting each value 
    in `uvd` to some sampling `constraint`(s) during resampling". Returns a vector of 
    length `length(uvals)` where the i-th element is a `n`-element vector of unique draws 
    of `uvals[i]`, where the support of `uvals[i]` has been truncated by the provided 
    `constraint`(s).

### Bug fixes

- [x] Removed extra blank line from print method for `AbstractUncertainPopulation`.