### PR TITLE
Resample `AbstractUncertainValueDataset`s element-wise, with and without constraints

### DIFF
--- a/src/resampling/Resampling.jl
+++ b/src/resampling/Resampling.jl
@@ -2,7 +2,6 @@ using Reexport
 
 @reexport module Resampling
 
-    
     ###################################
     # Resampling uncertain values
     ###################################
@@ -27,9 +26,13 @@ using Reexport
     ###################################
     # Resampling uncertain datasets
     ###################################
+
+    # Supertype for all uncertain value datasets
+    include("uncertain_dataset/resample_abstractuncertainvaluedataset.jl")
+
+    # Specialized resampling for each type of dataset.
     include("uncertain_dataset/resample_uncertaindataset.jl")
 	include("uncertain_dataset/resample_uncertaindataset_withconstraint.jl")
-
     include("uncertain_dataset/resample_uncertaindataset_index.jl")
     include("uncertain_dataset/resample_uncertaindataset_value.jl")
     include("uncertain_dataset/resample_uncertaindataset_indexvalue.jl")
@@ -46,7 +49,7 @@ using Reexport
     #########################################
     include("resampling_with_interpolation/resample_linear_interpolation.jl")
 
-    export resample
+    export resample, resample_elwise
 end # module
 
 

--- a/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
+++ b/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
@@ -1,4 +1,10 @@
 
+import ..UncertainDatasets:
+    AbstractUncertainValueDataset
+
+import ..SamplingConstraints: 
+    SamplingConstraint
+
 
 """
     resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
@@ -11,7 +17,8 @@ function resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
 end
 
 """
-    resample_elwise(uvd::UncertainIndexDataset, constraint::SamplingConstraint, n::Int)
+    resample_elwise(uvd::AbstractUncertainValueDataset, constraint::SamplingConstraint, 
+        n::Int)
 
 Resample each element in `uvals` `n` times. The i-th entry in the returned 
 vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`, drawn 

--- a/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
+++ b/src/resampling/uncertain_dataset/resample_abstractuncertainvaluedataset.jl
@@ -1,0 +1,24 @@
+
+
+"""
+    resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`.
+"""
+function resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
+    [resample(uvd[i], n) for i = 1:length(uvd)]
+end
+
+"""
+    resample_elwise(uvd::UncertainIndexDataset, constraint::SamplingConstraint, n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`, drawn 
+after first truncating the support of `uvals[i]` according to the provided `constraint`.
+"""
+function resample_elwise(uvd::AbstractUncertainValueDataset, 
+        constraint::SamplingConstraint, n::Int)
+    
+    [resample(uvd[i], constraint, n) for i = 1:length(uvd)]
+end

--- a/src/resampling/uncertain_dataset/resample_uncertaindataset_index.jl
+++ b/src/resampling/uncertain_dataset/resample_uncertaindataset_index.jl
@@ -23,6 +23,16 @@ function resample(uvd::UncertainIndexDataset, n::Int)
 end
 
 
+"""
+	resample_elwise(uvd::UncertainIndexDataset, n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`.
+"""
+function resample_elwise(uvd::UncertainIndexDataset, n::Int)
+    [resample(uvd[i], n) for i = 1:length(uvd)]
+end
+
 
 ##########################################################################
 # Draw realisations of the uncertain dataset according to the distributions
@@ -137,4 +147,15 @@ the supports of the distributions are truncated above at some quantile.
 function resample(uv::UncertainIndexDataset, constraint::TruncateQuantiles, n::Int)
 	L = length(uv)
 	[[resample(uv.indices[i], constraint) for i in 1:L] for k = 1:n]
+end
+
+"""
+    resample_elwise(uvd::UncertainIndexDataset, constraint::SamplingConstraint, n::Int)
+
+Resample each element in `uvals` `n` times. The i-th entry in the returned 
+vector is a `n`-element vector consisting of `n` unique draws of `uvals[i]`, drawn 
+after first truncating the support of `uvals[i]` according to the provided `constraint`.
+"""
+function resample_elwise(uvd::UncertainIndexDataset, constraint::SamplingConstraint, n::Int)
+    [resample(uvd[i], constraint, n) for i = 1:length(uvd)]
 end

--- a/src/resampling/uncertain_dataset/resample_uncertaindataset_index.jl
+++ b/src/resampling/uncertain_dataset/resample_uncertaindataset_index.jl
@@ -12,7 +12,7 @@ function resample(uvd::UncertainIndexDataset)
 end
 
 """
-	resample(uvd::UncertainIndexDataset)
+	resample(uvd::UncertainIndexDataset, n::Int)
 
 Draw `n` realisations of an `UncertainIndexDataset` according to the
 distributions of the `UncertainValue`s comprising it.

--- a/test/resampling/uncertain_datasets/test_resampling_elwise.jl
+++ b/test/resampling/uncertain_datasets/test_resampling_elwise.jl
@@ -1,0 +1,53 @@
+# Define some example data 
+import KernelDensity.UnivariateKDE
+o1 = UncertainValue(Normal, 0, 0.5)
+o2 = UncertainValue(Normal, 2.0, 0.1)
+o3 = UncertainValue(Uniform, 0, 4)
+o4 = UncertainValue(Uniform, rand(100))
+o5 = UncertainValue(Beta, 4, 5)
+o6 = UncertainValue(Gamma, 4, 5)
+o7 = UncertainValue(Frechet, 1, 2)
+o8 = UncertainValue(BetaPrime, 1, 2)
+o9 = UncertainValue(BetaBinomial, 10, 3, 2)
+o10 = UncertainValue(Binomial, 10, 0.3)
+o11 = UncertainValue(rand(100), rand(100))
+o12 = UncertainValue(2)
+o13 = UncertainValue(2.3)
+o14 = UncertainValue([2, 3, 4], [0.3, 0.4, 0.3])
+o15 = UncertainValue([rand() for i = 1:100])
+
+
+uvals1 = [o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o15, o4, o5, 
+    o6, o7, o8, o9, o11, o12, o13, o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, 
+    o14, o1, o2, o3, o4, o5, o6, o7, o8, o9, o11, o12, o13, o14]
+
+uvals2 = [uvals1[i] for i in [rand(1:length(uvals1)) for i = 1:length(uvals1)]]
+
+idxs = UncertainIndexDataset([UncertainValue(Normal, i, 0.8) for i = 1:length(uvals1)])
+
+UVD = UncertainValueDataset(uvals1)
+UD = UncertainDataset(uvals2)
+UIDX = UncertainIndexDataset(idxs)
+UV = UncertainValueDataset(uvals1)
+
+# Resampling interface should work for all subtypes of AbstractUncertainValueDataset,
+# both with and without sampling constraints.
+# We need to check UncertainDataset, UncertainIndexDataset, and UncertainValueDataset.
+
+n = 3
+
+#resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)
+@test length(resample_elwise(UIDX, n)) == length(UIDX)
+@test length(resample_elwise(UIDX, n)[1]) == n
+@test length(resample_elwise(UD, n)) == length(UD)
+@test length(resample_elwise(UD, n)[1]) == n
+@test length(resample_elwise(UVD, n)) == length(UVD)
+@test length(resample_elwise(UVD, n)[1]) == n
+
+# resample_elwise(uvd::AbstractUncertainValueDataset, constraint::SamplingConstraint, n::Int)
+@test length(resample_elwise(UIDX, TruncateQuantiles(0.1, 0.9), n)) == length(UIDX)
+@test length(resample_elwise(UIDX, TruncateQuantiles(0.1, 0.9), n)[1]) == n
+@test length(resample_elwise(UD, TruncateQuantiles(0.1, 0.9), n)) == length(UD)
+@test length(resample_elwise(UD, TruncateQuantiles(0.1, 0.9), n)[1]) == n
+@test length(resample_elwise(UVD, TruncateQuantiles(0.1, 0.9), n)) == length(UVD)
+@test length(resample_elwise(UVD, TruncateQuantiles(0.1, 0.9), n)[1]) == n

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ include("resampling/uncertain_values/test_resampling_certain_value.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues.jl")
 include("resampling/uncertain_values/test_resampling_uncertainvalues_kde.jl")
 
+include("resampling/uncertain_datasets/test_resampling_elwise.jl")
 include("resampling/uncertain_datasets/test_resampling_datasets.jl")
 include("resampling/uncertain_datasets/test_resampling_with_constraints.jl")
 include("resampling/uncertain_datasets/sequential/test_resampling_sequential_increasing.jl")


### PR DESCRIPTION
### New functionality and syntax changes
#### Resampling element-wise

- `resample_elwise(uvd::AbstractUncertainValueDataset, n::Int)` is now interpreted as 
    "draw `n` realisations of each value in `uvd`". Returns a vector of length `length(uvals)` 
    where the i-th element is a `n`-element vector of unique draws of `uvals[i]`. This works 
    for `UncertainDataset`s, `UncertainIndexDataset`s, and `UncertainValueDataset`s. 
- `resample_elwise(uvd::AbstractUncertainValueDataset, constraint::SamplingConstraint, n::Int)` 
    is now interpreted as "draw `n` realisations of each value in `uvd`, subjecting each value 
    in `uvd` to some sampling constraint during resampling". Returns a vector of 
    length `length(uvals)` where the i-th element is a `n`-element vector of unique draws 
    of `uvals[i]`, where the support of `uvals[i]` has been truncated by the provided 
    `constraint`.