### PR TITLE
Sampling constraints input validation

### DIFF
--- a/src/sampling_constraints/constraint_definitions.jl
+++ b/src/sampling_constraints/constraint_definitions.jl
@@ -53,6 +53,14 @@ should be truncated at some quantile quantile
 struct TruncateQuantiles <: ValueSamplingConstraint
     lower_quantile::Float64
     upper_quantile::Float64
+
+    function TruncateQuantiles(lower_quantile, upper_quantile)
+        if lower_quantile > upper_quantile
+            error("lower quantile > upper quantile ($lower_quantile > $upper_quantile)")
+        else
+            new(lower_quantile, upper_quantile)
+        end
+    end
 end
 
 """

--- a/src/sampling_constraints/constraint_definitions.jl
+++ b/src/sampling_constraints/constraint_definitions.jl
@@ -99,11 +99,18 @@ end
 A constraint indicating that the distribution furnishing an uncertain value
 should be truncated at some range `[min, max]`.
 """
-struct TruncateRange{T} <: ValueSamplingConstraint
-    min::T
-    max::T
+struct TruncateRange{T1, T2} <: ValueSamplingConstraint
+    min::T1
+    max::T2
+    
+    function TruncateRange(min::T1, max::T2) where {T1, T2}
+        if min < max
+            return new{T1, T2}(min, max)
+        else
+            error("Cannot create TruncateRange instance because min > max ($min > $max)")
+        end
+    end
 end
-
 
 
 export

--- a/src/sampling_constraints/constraint_definitions.jl
+++ b/src/sampling_constraints/constraint_definitions.jl
@@ -50,15 +50,17 @@ A constraint indicating that the distribution furnishing an uncertain value
 should be truncated at some quantile quantile
 `(lower_quantile, upper_quantile)`.
 """
-struct TruncateQuantiles <: ValueSamplingConstraint
-    lower_quantile::Float64
-    upper_quantile::Float64
+struct TruncateQuantiles{T1<:Real, T2<:Real} <: ValueSamplingConstraint
+    lower_quantile::T1
+    upper_quantile::T2
 
-    function TruncateQuantiles(lower_quantile, upper_quantile)
-        if lower_quantile > upper_quantile
-            error("lower quantile > upper quantile ($lower_quantile > $upper_quantile)")
+    function TruncateQuantiles(lower_quantile::T1, upper_quantile::T2) where {T1, T2}
+        err_msg = "Need 0 <= lower_quantile < upper_quantile <= 1"
+        
+        if !(lower_quantile < upper_quantile && 0.0 <= lower_quantile < upper_quantile <= 1.0)
+            throw(DomainError(err_msg * " (got lo = $lower_quantile, hi = $upper_quantile)"))
         else
-            new(lower_quantile, upper_quantile)
+            new{T1, T2}(lower_quantile, upper_quantile)
         end
     end
 end
@@ -73,8 +75,10 @@ struct TruncateStd{T<:Number} <: ValueSamplingConstraint
     nσ::T
     
     function TruncateStd(nσ::T) where T
+        
         if nσ <= 0
-            error("TruncateStd must be initialised with nσ strictly positive (got nσ = $nσ)")
+            err_str = "TruncateStd must be initialised with nσ strictly positive"
+            throw(DomainError(err_str *  " (got nσ = $nσ)"))
         else
             new{T}(nσ)
         end
@@ -115,7 +119,8 @@ struct TruncateRange{T1, T2} <: ValueSamplingConstraint
         if min < max
             return new{T1, T2}(min, max)
         else
-            error("Cannot create TruncateRange instance because min > max ($min > $max)")
+            err_msg = "Cannot create TruncateRange instance. Need min < max"
+            throw(DomainError(err_msg * " (got min = $min, max = $max)"))
         end
     end
 end

--- a/src/sampling_constraints/constraint_definitions.jl
+++ b/src/sampling_constraints/constraint_definitions.jl
@@ -71,6 +71,14 @@ should be truncated at `nσ` (`n` standard deviations).
 """
 struct TruncateStd{T<:Number} <: ValueSamplingConstraint
     nσ::T
+    
+    function TruncateStd(nσ::T) where T
+        if nσ <= 0
+            error("TruncateStd must be initialised with nσ strictly positive (got nσ = $nσ)")
+        else
+            new{T}(nσ)
+        end
+    end
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include("mathematics/test_mathematics.jl")
 include("uncertain_datasets/test_uncertain_datasets.jl")
 
 # SamplingConstraints module tests
+include("sampling_constraints/test_sampling_constraints.jl")
 include("sampling_constraints/test_constrain_certainvalue.jl")
 include("sampling_constraints/test_constrain_population.jl")
 include("sampling_constraints/test_constrain_uncertainvalues.jl")

--- a/test/sampling_constraints/test_constrain_uncertainvalues.jl
+++ b/test/sampling_constraints/test_constrain_uncertainvalues.jl
@@ -61,7 +61,7 @@ uv = UncertainValue(UnivariateKDE, rand(Uniform(10, 15), 1000))
 # distributon furnishing the data point
 @test_throws ArgumentError constrain(uv, TruncateMaximum(-100))
 @test_throws ArgumentError constrain(uv, TruncateMinimum(100))
-@test_throws ArgumentError constrain(uv, TruncateRange(100, -100))
+@test_throws DomainError constrain(uv, TruncateRange(100, -100))
 
 
 uvc_lq = constrain(uv, TruncateLowerQuantile(0.2))

--- a/test/sampling_constraints/test_sampling_constraints.jl
+++ b/test/sampling_constraints/test_sampling_constraints.jl
@@ -1,0 +1,18 @@
+# Test that input validation works where possible
+
+@test TruncateStd(1) isa TruncateStd{<:Int}
+@test TruncateStd(1.0) isa TruncateStd{<:Real}
+@test_throws DomainError TruncateStd(0) isa TruncateStd{<:Int}
+@test_throws DomainError TruncateStd(0.0) isa TruncateStd{<:Real}
+@test_throws DomainError TruncateStd(-1) isa TruncateStd{<:Int}
+@test_throws DomainError TruncateStd(-1.2) isa TruncateStd{<:Real}
+
+@test TruncateQuantiles(0.1, 0.9) isa TruncateQuantiles{<:Real, <:Real}
+@test TruncateQuantiles(0.0, 1.0) isa TruncateQuantiles{<:Real, <:Real}
+@test_throws DomainError TruncateQuantiles(-0.1, 0.9)
+@test_throws DomainError TruncateQuantiles(0.2, 1.9)
+@test_throws DomainError TruncateQuantiles(0.3, 0.1)
+
+@test TruncateRange(-10, 10) isa TruncateRange{<:Int, <:Int}
+@test TruncateRange(-10.0, 10) isa TruncateRange{<:Real, <:Int}
+@test_throws DomainError TruncateRange(5, 3)


### PR DESCRIPTION
### Improvements

- Added input validation when initialising `TruncateQuantiles`, `TruncateRange` and `TruncateStd`.
- Separate parameters types for `TruncateQuantiles` and `TruncateRange`, so one can do for example `TruncateRange(1, 8.0)`, instead of having to promote to `Float64`.