### PR TITLE
Release 0.2.3

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,3 +1,14 @@
+## UncertainData.jl v0.2.3
+
+### Improvements
+
+- Added input validation when initialising `TruncateQuantiles`, `TruncateRange` and 
+    `TruncateStd`.
+- Separate parameters types for `TruncateQuantiles` and `TruncateRange`, so one can do for 
+    example `TruncateRange(1, 8.0)`, instead of having to promote to `Float64`.
+- Added validation for distribution truncation when resampling.
+
+
 ## UncertainData.jl v0.2.2
 
 ### New functionality and syntax changes 

--- a/src/resampling/uncertain_values/resample_uncertainvalues_theoretical_withconstraints.jl
+++ b/src/resampling/uncertain_values/resample_uncertainvalues_theoretical_withconstraints.jl
@@ -250,6 +250,7 @@ function resample(uv::AbstractUncertainValue, constraint::TruncateMinimum)
     # Apply (another level of) truncation, then sample
     lower_bound = constraint.min
     upper_bound = support(uv.distribution).ub
+    lower_bound > upper_bound ? error("lower bound > upper_bound") : nothing
     rand(Truncated(uv.distribution, lower_bound, upper_bound))
 end
 
@@ -274,6 +275,7 @@ function resample(uv::AbstractUncertainValue, constraint::TruncateMinimum, n::In
     # Apply (another level of) truncation, then sample
     lower_bound = constraint.min
     upper_bound = support(uv.distribution).ub
+    lower_bound > upper_bound ? error("lower bound > upper_bound") : nothing
     rand(Truncated(uv.distribution, lower_bound, upper_bound), n)
 end
 
@@ -298,6 +300,7 @@ function resample(uv::AbstractUncertainValue, constraint::TruncateMaximum)
     # Apply (another level of) truncation, then sample
     upper_bound = constraint.max
     lower_bound = support(uv.distribution).lb
+    lower_bound > upper_bound ? error("lower bound > upper_bound") : nothing
     rand(Truncated(uv.distribution, lower_bound, upper_bound))
 end
 
@@ -322,6 +325,7 @@ function resample(uv::AbstractUncertainValue, constraint::TruncateMaximum, n::In
     # Apply (another level of) truncation, then sample
     lower_bound = support(uv.distribution).lb
     upper_bound = constraint.max
+    lower_bound > upper_bound ? error("lower bound > upper_bound") : nothing
     rand(Truncated(uv.distribution, lower_bound, upper_bound), n)
 end
 
@@ -348,6 +352,8 @@ function resample(uv::AbstractUncertainValue, constraint::TruncateRange)
     # Apply (another level of) truncation, then sample
     lower_bound = constraint.min
     upper_bound = constraint.max
+    lower_bound > upper_bound ? error("lower bound > upper_bound") : nothing
+
     rand(Truncated(uv.distribution, lower_bound, upper_bound))
 end
 
@@ -372,6 +378,8 @@ function resample(uv::AbstractUncertainValue, constraint::TruncateRange, n::Int)
     # Apply (another level of) truncation, then sample
     lower_bound = constraint.min
     upper_bound = constraint.max
+    lower_bound > upper_bound ? error("lower bound > upper_bound") : nothing
+
     rand(Truncated(uv.distribution, lower_bound, upper_bound), n)
 end
 
@@ -398,7 +406,7 @@ function resample(uv::AbstractUncertainValue, constraint::TruncateStd; n_draws::
     m = mean(resample(uv, n_draws))
     lower_bound = m - stdev
     upper_bound = m + stdev
-
+    lower_bound > upper_bound ? error("lower bound > upper_bound") : nothing
     rand(Truncated(uv.distribution, lower_bound, upper_bound))
 end
 

--- a/src/sampling_constraints/constraint_definitions.jl
+++ b/src/sampling_constraints/constraint_definitions.jl
@@ -50,9 +50,19 @@ A constraint indicating that the distribution furnishing an uncertain value
 should be truncated at some quantile quantile
 `(lower_quantile, upper_quantile)`.
 """
-struct TruncateQuantiles <: ValueSamplingConstraint
-    lower_quantile::Float64
-    upper_quantile::Float64
+struct TruncateQuantiles{T1<:Real, T2<:Real} <: ValueSamplingConstraint
+    lower_quantile::T1
+    upper_quantile::T2
+
+    function TruncateQuantiles(lower_quantile::T1, upper_quantile::T2) where {T1, T2}
+        err_msg = "Need 0 <= lower_quantile < upper_quantile <= 1"
+        
+        if !(lower_quantile < upper_quantile && 0.0 <= lower_quantile < upper_quantile <= 1.0)
+            throw(DomainError(err_msg * " (got lo = $lower_quantile, hi = $upper_quantile)"))
+        else
+            new{T1, T2}(lower_quantile, upper_quantile)
+        end
+    end
 end
 
 """
@@ -63,6 +73,16 @@ should be truncated at `nσ` (`n` standard deviations).
 """
 struct TruncateStd{T<:Number} <: ValueSamplingConstraint
     nσ::T
+    
+    function TruncateStd(nσ::T) where T
+        
+        if nσ <= 0
+            err_str = "TruncateStd must be initialised with nσ strictly positive"
+            throw(DomainError(err_str *  " (got nσ = $nσ)"))
+        else
+            new{T}(nσ)
+        end
+    end
 end
 
 """
@@ -91,11 +111,19 @@ end
 A constraint indicating that the distribution furnishing an uncertain value
 should be truncated at some range `[min, max]`.
 """
-struct TruncateRange{T} <: ValueSamplingConstraint
-    min::T
-    max::T
+struct TruncateRange{T1, T2} <: ValueSamplingConstraint
+    min::T1
+    max::T2
+    
+    function TruncateRange(min::T1, max::T2) where {T1, T2}
+        if min < max
+            return new{T1, T2}(min, max)
+        else
+            err_msg = "Cannot create TruncateRange instance. Need min < max"
+            throw(DomainError(err_msg * " (got min = $min, max = $max)"))
+        end
+    end
 end
-
 
 
 export

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include("mathematics/test_mathematics.jl")
 include("uncertain_datasets/test_uncertain_datasets.jl")
 
 # SamplingConstraints module tests
+include("sampling_constraints/test_sampling_constraints.jl")
 include("sampling_constraints/test_constrain_certainvalue.jl")
 include("sampling_constraints/test_constrain_population.jl")
 include("sampling_constraints/test_constrain_uncertainvalues.jl")

--- a/test/sampling_constraints/test_constrain_uncertainvalues.jl
+++ b/test/sampling_constraints/test_constrain_uncertainvalues.jl
@@ -61,7 +61,7 @@ uv = UncertainValue(UnivariateKDE, rand(Uniform(10, 15), 1000))
 # distributon furnishing the data point
 @test_throws ArgumentError constrain(uv, TruncateMaximum(-100))
 @test_throws ArgumentError constrain(uv, TruncateMinimum(100))
-@test_throws ArgumentError constrain(uv, TruncateRange(100, -100))
+@test_throws DomainError constrain(uv, TruncateRange(100, -100))
 
 
 uvc_lq = constrain(uv, TruncateLowerQuantile(0.2))

--- a/test/sampling_constraints/test_sampling_constraints.jl
+++ b/test/sampling_constraints/test_sampling_constraints.jl
@@ -1,0 +1,18 @@
+# Test that input validation works where possible
+
+@test TruncateStd(1) isa TruncateStd{<:Int}
+@test TruncateStd(1.0) isa TruncateStd{<:Real}
+@test_throws DomainError TruncateStd(0) isa TruncateStd{<:Int}
+@test_throws DomainError TruncateStd(0.0) isa TruncateStd{<:Real}
+@test_throws DomainError TruncateStd(-1) isa TruncateStd{<:Int}
+@test_throws DomainError TruncateStd(-1.2) isa TruncateStd{<:Real}
+
+@test TruncateQuantiles(0.1, 0.9) isa TruncateQuantiles{<:Real, <:Real}
+@test TruncateQuantiles(0.0, 1.0) isa TruncateQuantiles{<:Real, <:Real}
+@test_throws DomainError TruncateQuantiles(-0.1, 0.9)
+@test_throws DomainError TruncateQuantiles(0.2, 1.9)
+@test_throws DomainError TruncateQuantiles(0.3, 0.1)
+
+@test TruncateRange(-10, 10) isa TruncateRange{<:Int, <:Int}
+@test TruncateRange(-10.0, 10) isa TruncateRange{<:Real, <:Int}
+@test_throws DomainError TruncateRange(5, 3)


### PR DESCRIPTION
## Release v0.2.3

### Improvements

- Added input validation when initialising `TruncateQuantiles`, `TruncateRange` and `TruncateStd`.
- Separate parameters types for `TruncateQuantiles` and `TruncateRange`, so one can do for example `TruncateRange(1, 8.0)`, instead of having to promote to `Float64`.
- Added validation for distribution truncation when resampling.