### PR TITLE
Release v0.5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "UncertainData"
 uuid = "dcd9ba68-c27b-5cea-ae21-829cd07325bf"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>"]
 repo = "https://github.com/kahaaga/UncertainData.jl.git"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Bootstrap = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,6 +1,16 @@
 
 # Changelog
 
+## UncertainData.jl v0.5.1
+
+### Bug fixes
+
+- Strictly increasing or decreasing sequences were not always possible to construct 
+    when using `CertainValue`s, because `TruncateRange` instances with equal 
+    minimum and maximum was constructed (not possible). It is now possible to 
+    resample with sequential constraints even with the `StrictlyIncreasing` 
+    and `StrictlyDecreasing` constraints.
+
 ## UncertainData.jl v0.5.0
 
 ### Breaking changes

--- a/src/resampling/ordered_resampling/resample_uncertaindataset_strictlydecreasing.jl
+++ b/src/resampling/ordered_resampling/resample_uncertaindataset_strictlydecreasing.jl
@@ -45,7 +45,8 @@ function resample(udata::DT,
     # Some values may have infinite support even after applying the first round of 
     # constraints, so truncate to the provided (large) quantile range to ensure that all 
     # values have finite support when sampling.
-    constrained_data = constrain(udata, TruncateQuantiles(quantiles...,))
+    c = TruncateQuantiles(quantiles...,)
+    constrained_data = [udata[i] isa CertainValue ? udata[i] : constrain(udata[i], c) for i = 1:length(udata)]
 
     # Pre-allocate a sample 
     sample = Vector{Float64}(undef, n_vals)
@@ -54,8 +55,13 @@ function resample(udata::DT,
     # increasing sequence from indices 2:end will exist.
     hi = maximum(constrained_data[1])
     lo = minimum(maximum.(constrained_data[1:end]))
-    sample[1] = resample(constrained_data[1], TruncateRange(lo, hi))
 
+    if lo == hi 
+        sample[1] = resample(constrained_data[1])
+    else 
+        sample[1] = resample(constrained_data[1], TruncateRange(lo, hi))
+    end
+    
     for i = 2:n_vals - 1
         # Find the lower and upper bounds of the support from which we can draw values 
         # while still ensuring an increasing sequence of values.
@@ -65,8 +71,14 @@ function resample(udata::DT,
         
         # Constrain the support of the furnishing distribution according 
         # to the bounds and sample a value from it.
-        constrained_val = constrain(constrained_data[i], TruncateRange(lo, hi))
-        sample[i] = resample(constrained_val)
+        cd = constrained_data[i]
+
+        if cd isa CertainValue # no need to constrain if value is not uncertain
+            sample[i] = resample(cd)
+        else
+            constrained_val = constrain(cd, TruncateRange(lo, hi))
+            sample[i] = resample(constrained_val)
+        end
     end
 
     # The last value doesn't need an upper bound, because there's no 

--- a/test/resampling/uncertain_datasets/sequential/test_resampling_sequential_decreasing.jl
+++ b/test/resampling/uncertain_datasets/sequential/test_resampling_sequential_decreasing.jl
@@ -22,7 +22,7 @@ import Test
 # Create some uncertain data with decreasing magnitude and zero overlap between values, 
 # so we're guaranteed that a strictly decreasing sequence through the dataset exists.
 N = 10
-u_timeindices = [UncertainValue(Normal, i, rand(Uniform(0.1, 0.45))) for i = N:-1:1]
+u_timeindices = [ i <= N/2 ? CertainValue(float(i)) : UncertainValue(Normal, i, 1) for i = N:-1:1]
 u = UncertainDataset(u_timeindices)
 UI = UncertainIndexDataset(u_timeindices)
 UV = UncertainValueDataset(u_timeindices)

--- a/test/resampling/uncertain_datasets/sequential/test_resampling_sequential_increasing.jl
+++ b/test/resampling/uncertain_datasets/sequential/test_resampling_sequential_increasing.jl
@@ -22,7 +22,7 @@ import Test
 # Create some uncertain data with increasing magnitude and zero overlap between values, 
 # so we're guaranteed that a strictly increasing sequence through the dataset exists.
 N = 10
-u_timeindices = [UncertainValue(Normal, i, rand(Uniform(0.1, 0.45))) for i = 1:N]
+u_timeindices = [ i <= N/2 ? CertainValue(float(i)) : UncertainValue(Normal, i, 1) for i = 1:N]
 UI = UncertainIndexDataset(u_timeindices)
 UV = UncertainValueDataset(u_timeindices)
 


### PR DESCRIPTION
## Release v0.5.1

### Bug fixes

- Strictly increasing or decreasing sequences were not always possible to construct when using `CertainValue`s, because `TruncateRange` instances with equal minimum and maximum was constructed (not possible). It is now possible to resample with sequential constraints even with the `StrictlyIncreasing` and `StrictlyDecreasing` constraints.