### PR TITLE
Release 0.8.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "UncertainData"
 uuid = "dcd9ba68-c27b-5cea-ae21-829cd07325bf"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>"]
 repo = "https://github.com/kahaaga/UncertainData.jl.git"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Bootstrap = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## Uncertaindata.jl v0.8.1
+
+## Bug fixes
+
+- `rand(x::CertainValue, n::Int)` now returns a length-`n` array with `x` repeated `n` times.
+
 ## Uncertaindata.jl v0.8.0
 
 ### New functionality

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -3,6 +3,10 @@
 
 ## Uncertaindata.jl v0.8.1
 
+## New features
+
+- Added `UncertainValueDataset`, `UncertainIndexDataset`, and `UncertainIndexValueDataset` constructors for vectors of numbers (they get converted to `CertainValue`s). 
+
 ## Bug fixes
 
 - `rand(x::CertainValue, n::Int)` now returns a length-`n` array with `x` repeated `n` times.

--- a/src/uncertain_datasets/UncertainIndexDataset.jl
+++ b/src/uncertain_datasets/UncertainIndexDataset.jl
@@ -23,6 +23,10 @@ struct ConstrainedUncertainIndexDataset <: AbstractUncertainIndexDataset
     indices::AbstractVector{<:AbstractUncertainValue}
 end
 
+function UncertainIndexDataset(x::AbstractArray{T, 1}) where T
+    UncertainIndexDataset(CertainValue.(x))
+end
+
 export 
 UncertainIndexDataset,
 ConstrainedUncertainIndexDataset,

--- a/src/uncertain_datasets/UncertainIndexValueDataset.jl
+++ b/src/uncertain_datasets/UncertainIndexValueDataset.jl
@@ -136,6 +136,12 @@ struct UncertainIndexValueDataset{IDXTYP <: AbstractUncertainIndexDataset, VALST
     end
 end
 
+function UncertainIndexValueDataset(x::AbstractArray{T, 1}, y::AbstractArray{T, 1}) where T
+    idxs = UncertainIndexDataset(x)
+    vals = UncertainValueDataset(y)
+    UncertainIndexValueDataset(idxs, vals)
+end
+
 Base.length(u::UncertainIndexValueDataset) = length(u.values)
 Base.size(u::UncertainIndexValueDataset) = length(u.values)
 

--- a/src/uncertain_datasets/UncertainValueDataset.jl
+++ b/src/uncertain_datasets/UncertainValueDataset.jl
@@ -25,6 +25,10 @@ struct ConstrainedUncertainValueDataset <: AbstractUncertainValueDataset
     values::AbstractVector{<:AbstractUncertainValue}
 end
 
+function UncertainValueDataset(x::AbstractArray{T, 1}) where T
+    UncertainValueDataset(CertainValue.(x))
+end
+
 export
 UncertainValueDataset,
 ConstrainedUncertainValueDataset

--- a/src/uncertain_values/CertainValue.jl
+++ b/src/uncertain_values/CertainValue.jl
@@ -68,7 +68,7 @@ StatsBase.quantile(v::CertainValue, q, n::Int) = v.value
 StatsBase.std(v::CertainValue{T}) where {T} = zero(T)
 
 Base.rand(v::CertainValue) = v.value
-Base.rand(v::CertainValue, n) = repeat([v.value], n)
+Base.rand(v::CertainValue{T}, n::Int) where T = repeat([v.value], n)
 
 Base.float(v::CertainValue) = float(v.value)
 

--- a/src/uncertain_values/CertainValue.jl
+++ b/src/uncertain_values/CertainValue.jl
@@ -68,6 +68,8 @@ StatsBase.quantile(v::CertainValue, q, n::Int) = v.value
 StatsBase.std(v::CertainValue{T}) where {T} = zero(T)
 
 Base.rand(v::CertainValue) = v.value
+Base.rand(v::CertainValue, n) = repeat([v.value], n)
+
 Base.float(v::CertainValue) = float(v.value)
 
 function Base.:<(x::CertainValue{T1}, y::CertainValue{T2}) where {

--- a/test/resampling/uncertain_values/test_resampling_certain_value.jl
+++ b/test/resampling/uncertain_values/test_resampling_certain_value.jl
@@ -14,7 +14,7 @@ test_constraints = [
 T = eltype(x)
 
 @test rand(x) isa T
-@test rand(x, 10) isa Vector{T}
+@test rand(x, 10) isa Vector
 
 @test resample(x) isa T
 @test resample(x, 10) isa Vector

--- a/test/resampling/uncertain_values/test_resampling_certain_value.jl
+++ b/test/resampling/uncertain_values/test_resampling_certain_value.jl
@@ -13,6 +13,9 @@ test_constraints = [
 
 T = eltype(x)
 
+@test rand(x) isa T
+@test rand(x, 10) isa Vector{T}
+
 @test resample(x) isa T
 @test resample(x, 10) isa Vector
 @test all(resample(x, 10) .== x.value)

--- a/test/uncertain_datasets/test_uncertain_index_dataset.jl
+++ b/test/uncertain_datasets/test_uncertain_index_dataset.jl
@@ -1,0 +1,1 @@
+@test UncertainIndexDataset(rand(30)) isa UncertainIndexDataset

--- a/test/uncertain_datasets/test_uncertain_index_value_dataset.jl
+++ b/test/uncertain_datasets/test_uncertain_index_value_dataset.jl
@@ -19,6 +19,9 @@ UI = UncertainIndexDataset(uvals)
 CUV = constrain(UV, TruncateQuantiles(0.1, 0.9))
 CUI = constrain(UV, TruncateQuantiles(0.1, 0.9))
 
+# From scalar vectors 
+@test UncertainIndexValueDataset(rand(30), rand(30)) isa UncertainIndexValueDataset
+
 # Vectors
 @test UncertainIndexValueDataset(uvals, uvals) isa UncertainIndexValueDataset
 

--- a/test/uncertain_datasets/test_uncertain_value_dataset.jl
+++ b/test/uncertain_datasets/test_uncertain_value_dataset.jl
@@ -1,0 +1,1 @@
+@test UncertainValueDataset(rand(30)) isa UncertainValueDataset


### PR DESCRIPTION
## Bug fixes 

- Added missing `rand(x::CertainValue, n::Int)` method. Needed for resampling `UncertainIndexValueDataset`s where either indices or values are certain.