### PR TITLE
Release 0.9.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "UncertainData"
 uuid = "dcd9ba68-c27b-5cea-ae21-829cd07325bf"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>"]
 repo = "https://github.com/kahaaga/UncertainData.jl.git"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Bootstrap = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## Uncertaindata.jl v0.9.1
+
+### Bug fixes
+
+- Missing import of `interpolate_and_bin` between sub-packages fixed.
+
 ## Uncertaindata.jl v0.9.0
 
 ### New features

--- a/src/resampling/resampling_with_schemes/resampling_schemes_interpolated_binned.jl
+++ b/src/resampling/resampling_with_schemes/resampling_schemes_interpolated_binned.jl
@@ -1,3 +1,5 @@
+import ..InterpolationAndGrids: interpolate_and_bin
+
 """
     resample(udata::AbstractUncertainIndexValueDataset, regularization_scheme::InterpolateAndBin{Linear})
 


### PR DESCRIPTION
## Uncertaindata.jl v0.9.1

### Bug fixes

- Missing import of `interpolate_and_bin` between sub-packages fixed.