### PR TITLE
Release v0.10.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "UncertainData"
 uuid = "dcd9ba68-c27b-5cea-ae21-829cd07325bf"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>"]
 repo = "https://github.com/kahaaga/UncertainData.jl.git"
-version = "0.9.3"
+version = "0.10.0"
 
 [deps]
 Bootstrap = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,6 +1,14 @@
 
 # Changelog
 
+## UncertainData.jl v0.10.0
+
+### Improvements
+
+- The `resample` family of methods for vectors now dispatches on `AbstractVector`s, which allows more 
+    flexibility. Now, for example `LArray`s from `LabelledArrays.jl` also can be resampled.
+- Relax `resample(x::Real)` to `resample(x::Number)`.
+
 ## UncertainData.jl v0.9.3
 
 - `dimension` is no longer exported.

--- a/src/resampling/uncertain_values/resample_certainvalues.jl
+++ b/src/resampling/uncertain_values/resample_certainvalues.jl
@@ -1,7 +1,7 @@
 import ..SamplingConstraints: SamplingConstraint
 import ..UncertainValues: CertainValue
 
-resample(x::Real) = x
+resample(x::Number) = x
 
 resample(v::CertainValue) = v.value 
 resample(v::CertainValue, n::Int) = [v.value for i = 1:n]

--- a/src/resampling/uncertain_vectors/resample_uncertain_vectors.jl
+++ b/src/resampling/uncertain_vectors/resample_uncertain_vectors.jl
@@ -1,43 +1,45 @@
 
+resample(uv::AbstractVector{<:Number}) = uv
+
 # No constraints
-function resample(uv::DT) where {DT <: Vector{<:AbstractUncertainValue}}
+function resample(uv::DT) where {DT <: AbstractVector{<:AbstractUncertainValue}}
     resample.(uv)
 end
 
-function resample(uv::DT, n::Int) where {DT <: Vector{<:AbstractUncertainValue}}
+function resample(uv::DT, n::Int) where {DT <: AbstractVector{<:AbstractUncertainValue}}
     [resample.(uv) for i = 1:n]
 end
 
 # Vectors of sampling constraints mapped to unique sampling constraints
 function resample(uv::DT, constraint::Vector{<:SamplingConstraint}) where {
-        DT <: Vector{<:AbstractUncertainValue}}
+        DT <: AbstractVector{<:AbstractUncertainValue}}
     [resample(uv[i], constraint[i]) for i in 1:length(uv)]
 end
 
 function resample(uv::DT, constraint::Vector{<:SamplingConstraint}, n::Int) where {
-        DT <: Vector{<:AbstractUncertainValue}}
+        DT <: AbstractVector{<:AbstractUncertainValue}}
     [[resample(uv[i], constraint[i]) for i in 1:length(uv)] for k = 1:n]
 end
 
 # Vectors of sampling constraints mapped to unique sampling constraints
 function resample(uv::DT, constraint::SamplingConstraint) where {
-        DT <: Vector{<:AbstractUncertainValue}}
+        DT <: AbstractVector{<:AbstractUncertainValue}}
     [resample(uv[i], constraint) for i in 1:length(uv)]
 end
 
 function resample(uv::DT, constraint::SamplingConstraint, n::Int) where {
-        DT <: Vector{<:AbstractUncertainValue}}
+        DT <: AbstractVector{<:AbstractUncertainValue}}
     [[resample(uv[i], constraint) for i in 1:length(uv)] for k = 1:n]
 end
 
 function resample(uv::DT, constraint::NoConstraint) where {
-    DT <: Vector{<:AbstractUncertainValue}}
+    DT <: AbstractVector{<:AbstractUncertainValue}}
 
     return uv
 end
 
 function resample(uv::DT, constraint::NoConstraint, n::Int) where {
-    DT <: Vector{<:AbstractUncertainValue}}
+    DT <: AbstractVector{<:AbstractUncertainValue}}
     
     return [uv for i = 1:n]
 end


### PR DESCRIPTION
## Release 0.10.0

### Improvements 

- Resample for vectors now dispatches on `AbstractVector`s. This allows for flexibility, for example using `LArray`s from LabelledArrays.jl.
- Relax `resample(x::Real)` to `resample(x::Number)`.