### PR TITLE
Release 0.10.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "UncertainData"
 uuid = "dcd9ba68-c27b-5cea-ae21-829cd07325bf"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>"]
 repo = "https://github.com/kahaaga/UncertainData.jl.git"
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 Bootstrap = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -58,6 +58,10 @@ PAGES = [
         "sampling_constraints/ordered_sequence_exists.md",
         "sampling_constraints/sequential_constraints.md"
     ],
+
+    "Binning" => [
+        "binning/bin_BinnedResampling.md"
+    ],
     "Resampling" => [
         "resampling/resampling_overview.md",
         "resampling/resampling_uncertain_values.md",

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,6 +72,8 @@ pages:
       - Existence of sequences: sampling_constraints/ordered_sequence_exists.md
     - Examples:
       - Constraining uncertain values: sampling_constraints/constrain_uncertain_values.md
+  - Binning:
+    - BinnedResampling: binning/bin_BinnedResampling.md
   - Resampling:
     - Overview: resampling/resampling_overview.md
     - Uncertain values: 

--- a/docs/src/binning/bin_BinnedResampling.md
+++ b/docs/src/binning/bin_BinnedResampling.md
@@ -1,0 +1,31 @@
+
+# Binning
+
+## [Scalar data](@id bin_scalar_valued_data)
+
+### Get bin values
+
+```@docs
+bin(left_bin_edges::AbstractRange, xs, ys)
+bin!(bins::Vector{AbstractVector}, left_bin_edges::AbstractRange, xs, ys)
+```
+
+### Summarise bins
+
+```@docs
+bin(f::Function, left_bin_edges::AbstractRange, xs, ys)
+```
+
+## [Uncertain data](@id bin_uncertain_data_BinnedResampling)
+
+### Get bin values
+
+```@docs
+bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling{RawValues})
+```
+
+### Summarise bins
+
+```@docs
+bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling)
+```

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,6 +1,20 @@
 
 # Changelog
 
+## UncertainData.jl v0.10.2
+
+### Improvements
+
+- The user can now control how each bin is represented when using `BinnedResampling`. One can now 
+    provide `BinnedResampling{UncertainScalarKDE}`, `BinnedResampling{UncertainScalarPopulaton}` or 
+    `BinnedResampling{RawValues}`.
+- Explicit `bin` methods for binning both scalar valued data and uncertain data.
+
+### Documentation
+
+- Added documentation for binning methods.
+- Improved documentation for `UncertainScalarKDE`.
+
 ## UncertainData.jl v0.10.0
 
 ### Improvements

--- a/src/resampling/Resampling.jl
+++ b/src/resampling/Resampling.jl
@@ -3,6 +3,7 @@ using Reexport
 @reexport module Resampling
     import Interpolations
     import Interpolations: Linear, BoundaryCondition
+    import ..InterpolationAndGrids: bin
 
     import ..UVAL_COLLECTION_TYPES
     import ..UncertainDatasets: 
@@ -104,7 +105,12 @@ using Reexport
     include("resampling_with_schemes/resampling_schemes_constrained.jl")
     include("resampling_with_schemes/resampling_schemes_sequential.jl")
 
-    export resample, resample!, resample_elwise
+    ################################
+    # Interpolation
+    ################################
+    include("binning/bin_BinnedResampling.jl")
+
+    export resample, resample!, resample_elwise, bin
 end # module
 
 

--- a/src/resampling/binning/bin_BinnedResampling.jl
+++ b/src/resampling/binning/bin_BinnedResampling.jl
@@ -1,0 +1,184 @@
+import KernelDensity: UnivariateKDE, default_bandwidth, kde
+import Distributions: Distribution
+
+"""
+    bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling{UncertainScalarKDE}) -> UncertainIndexValueDataset
+    bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling{UncertainScalarPopulation}) -> UncertainIndexValueDataset
+
+Resample every element of `x` the number of times given by `binning.n`. After resampling,
+distribute the values according to their indices in the bins given by `binning.left_bin_edges`.
+
+## Returns 
+
+Returns an `UncertainIndexValueDataset`. Indices are assumed to be uniformly distributed within each 
+bin, and are represented as `CertainValue`s at the bin centers. Values of the dataset have different 
+representations depending on what `binning` is:
+
+- If `binning isa BinnedResampling{UncertainScalarKDE}`, values in each bin are represented by a 
+    kernel density estimate to the distribution of the resampled values whose resampled indices 
+    fall in that bin.
+- If `binning isa BinnedResampling{UncertainScalarPopulation}`, values in each bin are 
+    represented by equiprobable populations consisting of the resampled values whose resampled 
+    indices fall in the bins.
+"""
+function bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling); end
+
+"""
+    bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling{RawValues}) -> Tuple(Vector, Vector{Vector})
+
+Resample every element of `x` the number of times given by `binning.n`. After resampling,
+distribute the values according to their indices in the bins given by `binning.left_bin_edges`.
+
+For each bin, return a tuple containing the `N` different bin centers and a `N`-length vector of 
+resampled values whose resampled indices fall in the `N` different bins.
+
+## Example 
+
+```julia
+# Some example data with unevenly spaced time indices
+npts = 300
+time, vals = sort(rand(1:1000, npts)), rand(npts)
+
+# Add uncertainties to indices and values, and represent as 
+# UncertainIndexValueDataset 
+utime = [UncertainValue(Normal, t, 10) for t in time]
+uvals = [UncertainValue(Normal, v, 0.1) for v in vals]
+
+udata = UncertainIndexValueDataset(utime, uvals)
+
+# Bin data into fall in 25 time step wide time bins ranging 
+# from time indices 100 to 900 and return a vector of raw 
+# values for each bin. Do this by resampling each uncertain
+# data point 10000 times and distributing those draws among 
+# the bins.
+left_bin_edges = 100:25:900
+n_draws = 10000
+binning = BinnedResampling(RawValues, left_bin_edges, n_draws)
+
+bin_centers, bin_draws = bin(udata, binning)
+```
+"""
+function bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling{RawValues};
+        nan_threshold = 0.0)
+    # Pre-allocate some arrays into which we resample the values of the 
+    # index and value populations.
+    idxs = fill(NaN, binning.n)
+    vals = fill(NaN, binning.n)
+
+    perminds = zeros(Int, binning.n)
+    sorted_idxs = fill(NaN, binning.n)
+    sorted_vals = fill(NaN, binning.n)
+
+    bin_edges = binning.left_bin_edges
+    n_bins = length(bin_edges) - 1
+
+    # Used to compute the index of the bin into which a draw belongs
+    mini = minimum(binning.left_bin_edges)
+    s = step(binning.left_bin_edges)
+        
+    # Empty vectors that will contain draws.
+    binvecs = [Vector{Float64}(undef, 0) for i = 1:n_bins] 
+    #[sizehint!(bv, resampling.n*n_bins) for bv in binvecs]
+
+    @inbounds for (j, (idx, val)) in enumerate(zip(x.indices, x.values))
+        # Resample the j-th index and j-th value
+        resample!(idxs, idx)
+        resample!(vals, val)
+        
+        # Get the vector that sorts the index vector, and use that to 
+        # sort the draws.
+        sortperm!(perminds, idxs)
+        sorted_idxs .= idxs[perminds]
+        sorted_vals .= vals[perminds]
+        
+        # The vectors above are sorted sorted, so this can be done faster
+        for i in 1:n_bins
+            inbin = findall(bin_edges[i] .<= sorted_idxs .<= bin_edges[i+1])
+            if length(inbin) > nan_threshold
+                append!(binvecs[i], sorted_vals[inbin])
+            end
+        end
+    end
+    
+    bin_centers = bin_edges[1:end-1] .+ step(bin_edges)/2
+    
+    return bin_centers, binvecs
+end
+
+function bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling{UncertainScalarPopulation};
+        nan_threshold = 0)
+    
+    # Get bin center and a vector for each bin containing the values falling in that bin.
+    left_bin_edges = binning.left_bin_edges
+    n = binning.n
+    n_bins = length(left_bin_edges) - 1
+
+    bin_centers, binvecs = bin(x, BinnedResampling(RawValues, left_bin_edges, n))
+    
+    # Estimate distributions in each bin by kernel density estimation
+    estimated_value_dists = Vector{Union{CertainValue, UncertainScalarPopulation}}(undef, n_bins)
+    binvec_lengths = length.(binvecs)
+    
+    for i in 1:n_bins        
+        L = binvec_lengths[i]
+        # If bin contains enough values, represent as population. Otherwise, 
+        # set to NaN.
+        if L > nan_threshold
+            probs = Weights(repeat([1/L], L))
+            estimated_value_dists[i] = UncertainScalarPopulation(binvecs[i], probs)
+        else 
+            estimated_value_dists[i] = UncertainValue(NaN)
+        end
+    end
+    
+    new_inds = UncertainIndexDataset(bin_centers)
+    new_vals = UncertainValueDataset(estimated_value_dists)
+    
+    UncertainIndexValueDataset(new_inds, new_vals)
+end
+
+function bin(x::AbstractUncertainIndexValueDataset, binning::BinnedResampling{UncertainScalarKDE};
+        nan_threshold = 0, 
+        kernel::Type{D} = Normal, 
+        bw_factor = 4,
+        npoints::Int = 2048) where {K <: UnivariateKDE, D <: Distribution}
+    
+    # Get bin center and a vector for each bin containing the values falling in that bin.
+    left_bin_edges = binning.left_bin_edges
+    n = binning.n
+    n_bins = length(left_bin_edges) - 1
+
+    bin_centers, binvecs = bin(x, BinnedResampling(RawValues, left_bin_edges, n))
+    
+    # Estimate distributions in each bin by kernel density estimation
+    estimated_value_dists = Vector{Union{CertainValue, UncertainScalarKDE}}(undef, n_bins)
+    binvec_lengths = length.(binvecs)
+    
+    for i in 1:n_bins        
+        L = binvec_lengths[i]
+        # If bin contains enough values, represent as KDE estimate. Otherwise, 
+        # set to NaN.
+        if L > nan_threshold
+            bw = default_bandwidth(binvecs[i]) / bw_factor
+            # Kernel density estimation
+            KDE = kde(binvecs[i], npoints = npoints, kernel = kernel, bandwidth = bw)
+
+            # Get the x value for which the density is estimated.
+            xrange = KDE.x
+
+            # Normalise estimated density
+            density = KDE.density ./ sum(KDE.density)
+
+            estimated_value_dists[i] = UncertainScalarKDE(KDE, binvecs[i], xrange, Weights(density))
+        else 
+            estimated_value_dists[i] = UncertainValue(NaN)
+        end
+    end
+    
+    new_inds = UncertainIndexDataset(bin_centers)
+    new_vals = UncertainValueDataset(estimated_value_dists)
+    
+    UncertainIndexValueDataset(new_inds, new_vals)
+end
+
+export bin

--- a/src/uncertain_values/UncertainScalarsKDE.jl
+++ b/src/uncertain_values/UncertainScalarsKDE.jl
@@ -10,12 +10,13 @@ import Base:
     max, min
 
 """
-    UncertainScalarKDE
+    UncertainScalarKDE(d::KernelDensity.UnivariateKDE, values::AbstractVector{T}, range, pdf)
 
 An empirical value represented by a distribution estimated from actual data.
 
 ## Fields
-- **`distribution`**: The `UnvariateKDE` estimate for the distribution of `values`.
+
+- **`distribution`**: The `UnivariateKDE` estimate for the distribution of `values`.
 - **`values`**: The values from which `distribution` is estimated.
 - **`range`**: The values for which the pdf is estimated.
 - **`pdf`**: The values of the pdf at each point in `range`.

--- a/test/resampling/binning/test_bin_BinnedResampling.jl
+++ b/test/resampling/binning/test_bin_BinnedResampling.jl
@@ -1,0 +1,53 @@
+using DynamicalSystemsBase
+
+function eom_ar1_unidir(x, p, n)
+    a₁, b₁, c_xy, σ = (p...,)
+    x, y = (x...,)
+    ξ₁ = rand(Normal(0, σ))
+    ξ₂ = rand(Normal(0, σ))
+    
+    dx = a₁*x + ξ₁
+    dy = b₁*y + c_xy*x + ξ₂
+    return SVector{2}(dx, dy)
+end
+
+function ar1_unidir(;uᵢ = rand(2), a₁ = 0.90693, b₁ = 0.40693, c_xy = 0.5, σ = 0.40662)
+    p = [a₁, b₁, c_xy, σ]
+    DiscreteDynamicalSystem(eom_ar1_unidir, uᵢ, p)
+end
+
+
+vars = (1, 2)
+npts, tstep = 50, 50
+d_xind = Uniform(2.5, 5.5)
+d_yind = Uniform(2.5, 5.5)
+d_xval = Uniform(0.01, 0.2)
+d_yval = Uniform(0.01, 0.2)
+
+X, Y = example_uncertain_indexvalue_datasets(ar1_unidir(c_xy = 0.5), npts, vars, tstep = tstep,
+    d_xind = d_xind, d_yind = d_yind,
+    d_xval = d_xval, d_yval = d_yval);
+
+time_grid = -20:100:2540
+n_draws = 10000 # draws per uncertain value
+n_bins = length(time_grid) - 1
+
+# Values in each bin represented as RawValues 
+b = BinnedResampling(RawValues, time_grid, n_draws)
+bc, vs = bin(Y, b);
+
+@test vs isa Vector{Vector{T}} where T
+@test length(vs) == n_bins
+@test sum(length.(vs)) == length(Y)*n_draws
+
+# Values in each bin represented as UncertainScalarKDE
+b_kde = BinnedResampling(UncertainScalarKDE, time_grid, n_draws)
+Y_binned = bin(Y, b_kde);
+
+@test Y_binned isa AbstractUncertainIndexValueDataset 
+
+# Values in each bin represented as UncertainScalarPopulation
+b_pop = BinnedResampling(UncertainScalarPopulation, time_grid, n_draws)
+Y_binned = bin(Y, b_pop);
+
+@test Y_binned isa AbstractUncertainIndexValueDataset 

--- a/test/resampling/resampling_schemes/test_BinnedResampling.jl
+++ b/test/resampling/resampling_schemes/test_BinnedResampling.jl
@@ -4,3 +4,23 @@ resampling = BinnedResampling(grid, n_draws)
 
 @test resampling isa BinnedResampling
 @test typeof(resampling) <: AbstractBinnedUncertainValueResampling
+
+# Create the resampling scheme. Use kernel density estimates to distribution 
+# in each bin.
+resampling = BinnedResampling(grid, n_draws, bin_repr = UncertainScalarKDE)
+@test resampling isa BinnedResampling{UncertainScalarKDE}
+resampling = BinnedResampling(UncertainScalarKDE, grid, n_draws)
+@test resampling isa BinnedResampling{UncertainScalarKDE}
+
+# Represent each bin as an equiprobably population 
+resampling = BinnedResampling(grid, n_draws, bin_repr = UncertainScalarPopulation)
+@test resampling isa BinnedResampling{UncertainScalarPopulation}
+resampling = BinnedResampling(UncertainScalarPopulation, grid, n_draws)
+@test resampling isa BinnedResampling{UncertainScalarPopulation}
+
+# Keep raw values for each bin (essentially the same as UncertainScalarPopulation,
+# but avoids storing an additional vector of weights for the population members).
+resampling = BinnedResampling(grid, n_draws, bin_repr = RawValues)
+@test resampling isa BinnedResampling{RawValues}
+resampling = BinnedResampling(RawValues, grid, n_draws)
+@test resampling isa BinnedResampling{RawValues}

--- a/test/resampling/resampling_schemes/test_BinnedWeightedResampling.jl
+++ b/test/resampling/resampling_schemes/test_BinnedWeightedResampling.jl
@@ -5,3 +5,23 @@ resampling = BinnedWeightedResampling(grid, wts, n_draws)
 
 @test resampling isa BinnedWeightedResampling
 @test typeof(resampling) <: AbstractBinnedUncertainValueResampling
+
+# Create the resampling scheme. Use kernel density estimates to distribution 
+# in each bin.
+resampling = BinnedWeightedResampling(grid, wts, n_draws, bin_repr = UncertainScalarKDE)
+@test resampling isa BinnedWeightedResampling{UncertainScalarKDE}
+resampling = BinnedWeightedResampling(UncertainScalarKDE, grid, wts, n_draws)
+@test resampling isa BinnedWeightedResampling{UncertainScalarKDE}
+
+# Represent each bin as an equiprobably population 
+resampling = BinnedWeightedResampling(grid, wts, n_draws, bin_repr = UncertainScalarPopulation)
+@test resampling isa BinnedWeightedResampling{UncertainScalarPopulation}
+resampling = BinnedWeightedResampling(UncertainScalarPopulation, grid, wts, n_draws)
+@test resampling isa BinnedWeightedResampling{UncertainScalarPopulation}
+
+# Keep raw values for each bin (essentially the same as UncertainScalarPopulation,
+# but avoids storing an additional vector of weights for the population members).
+resampling = BinnedWeightedResampling(grid, wts, n_draws, bin_repr = RawValues)
+@test resampling isa BinnedWeightedResampling{RawValues}
+resampling = BinnedWeightedResampling(RawValues, grid, wts, n_draws)
+@test resampling isa BinnedWeightedResampling{RawValues}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,9 @@ include("generic_interpolation/test_interpolate_nans.jl")
 include("resampling/uncertain_datasets/test_interpolation.jl")
 include("binning/test_binning.jl")
 
+# Interpolation with resampling schemes
+include("resampling/binning/test_bin_BinnedResampling.jl")
+
 #############################
 # Mathematics
 #############################


### PR DESCRIPTION
### Improvements

- The user can now control how each bin is represented when using `BinnedResampling`. One can now 
    provide `BinnedResampling{UncertainScalarKDE}`, `BinnedResampling{UncertainScalarPopulaton}` or 
    `BinnedResampling{RawValues}`.
- Explicit `bin` methods for binning both scalar valued data and uncertain data.

### Documentation

- Added documentation for binning methods.
- Improved documentation for `UncertainScalarKDE`.