### PR TITLE
Bugfix in resample `UncertainIndexValueDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# UncertainData changelog
+
+## v0.12.0
+
+### Bug fixes
+
+- Fixed bug where indices were sampled instead of values for the method 
+    `resample(x::UncertainIndexValueDataset, constraint::SamplingConstraint, sequential_constraint::Union{StrictlyDecreasing, StrictlyDecreasing}`.
+

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "UncertainData"
 uuid = "dcd9ba68-c27b-5cea-ae21-829cd07325bf"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>"]
 repo = "https://github.com/kahaaga/UncertainData.jl.git"
-version = "0.11.0"
+version = "0.12.0"
 
 [deps]
 Bootstrap = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"

--- a/src/resampling/ordered_resampling/resample_uncertaindataset_strictlydecreasing.jl
+++ b/src/resampling/ordered_resampling/resample_uncertaindataset_strictlydecreasing.jl
@@ -155,7 +155,7 @@ function resample(udata::UncertainIndexValueDataset,
         sequential_constraint::StrictlyDecreasing{<:OrderedSamplingAlgorithm})
 
     inds = resample(constrain(udata.indices, constraint), sequential_constraint)
-    vals = resample(constrain(udata.indices, constraint))
+    vals = resample(constrain(udata.values, constraint))
 
     inds, vals
 end
@@ -165,7 +165,7 @@ function resample(udata::UncertainIndexValueDataset,
         sequential_constraint::StrictlyDecreasing{<:OrderedSamplingAlgorithm})
 
     inds = resample(constrain(udata.indices, constraint), sequential_constraint)
-    vals = resample(constrain(udata.indices, constraint))
+    vals = resample(constrain(udata.values, constraint))
 
     inds, vals
 end
@@ -176,7 +176,7 @@ function resample(udata::UncertainIndexValueDataset,
         sequential_constraint::StrictlyDecreasing{<:OrderedSamplingAlgorithm})
     
     inds = resample(constrain(udata.indices, idx_constraint), sequential_constraint)
-    vals = resample(constrain(udata.indices, value_constraint))
+    vals = resample(constrain(udata.values, value_constraint))
 
     inds, vals
 end
@@ -188,7 +188,7 @@ function resample(udata::UncertainIndexValueDataset,
         sequential_constraint::StrictlyDecreasing{<:OrderedSamplingAlgorithm})
 
     inds = resample(constrain(udata.indices, idx_constraint), sequential_constraint)
-    vals = resample(constrain(udata.indices, value_constraint))
+    vals = resample(constrain(udata.values, value_constraint))
 
     inds, vals
 end
@@ -200,7 +200,7 @@ function resample(udata::UncertainIndexValueDataset,
         sequential_constraint::StrictlyDecreasing{<:OrderedSamplingAlgorithm})
 
     inds = resample(constrain(udata.indices, idx_constraint), sequential_constraint)
-    vals = resample(constrain(udata.indices, value_constraint))
+    vals = resample(constrain(udata.values, value_constraint))
 
     inds, vals
 end
@@ -211,7 +211,7 @@ function resample(udata::UncertainIndexValueDataset,
         sequential_constraint::StrictlyDecreasing{<:OrderedSamplingAlgorithm})
 
     inds = resample(constrain(udata.indices, idx_constraint), sequential_constraint)
-    vals = resample(constrain(udata.indices, value_constraint))
+    vals = resample(constrain(udata.values, value_constraint))
 
     inds, vals
 end

--- a/src/sampling_constraints/ordered_sequences/ordered_sequence_algorithms.jl
+++ b/src/sampling_constraints/ordered_sequences/ordered_sequence_algorithms.jl
@@ -6,7 +6,7 @@ An abstract type for ordered sampling algorithms.
 abstract type OrderedSamplingAlgorithm end 
 
 """
-    OrderedSamplingStartToEnd
+    StartToEnd
 
 An ordered sampling algorithm indicating that values should be 
 treated consecutively from start to finish of the dataset.
@@ -14,7 +14,7 @@ treated consecutively from start to finish of the dataset.
 struct StartToEnd <: OrderedSamplingAlgorithm end 
 
 """
-    OrderedSamplingEndToStart
+    EndToStart
 
 An ordered sampling algorithm indicating that the values should be 
 treated consecutively from the end to the start of the dataset.
@@ -22,7 +22,7 @@ treated consecutively from the end to the start of the dataset.
 struct EndToStart <: OrderedSamplingAlgorithm end
 
 """
-    OrderedSamplingMidpointOutwards
+    MidpointOutwards
 
 An ordered sampling algorithm indicating that the values should be 
 divided into two groups, separating the values at some midpoint 
@@ -33,7 +33,7 @@ struct MidpointOutwards <: OrderedSamplingAlgorithm
 end
 
 """
-    OrderedSamplingChuncksForwards
+    ChuncksForwards
 
 An ordered sampling algorithm indicating that the values should be 
 divided into multiple (`n_chunks`) groups. The groups of values 
@@ -45,7 +45,7 @@ struct ChunksForwards <: OrderedSamplingAlgorithm
 end
 
 """
-    OrderedSamplingChuncksForwards
+    ChuncksBackwards
 
 An ordered sampling algorithm indicating that the values should be 
 divided into multiple (`n_chunks`) groups. The groups of values 


### PR DESCRIPTION
- Fixed bug where indices were sampled instead of values for the method 
    `resample(x::UncertainIndexValueDataset, constraint::SamplingConstraint, sequential_constraint::Union{StrictlyDecreasing, StrictlyDecreasing}`.
