### PR TITLE
Fix uneven trailing whitespace in strings

### DIFF
--- a/src/mathematics/uncertainvalues/elementary_operations_uncertainvalues_special_cases.jl
+++ b/src/mathematics/uncertainvalues/elementary_operations_uncertainvalues_special_cases.jl
@@ -7,7 +7,7 @@ for operator in operators
     funcs = quote 
         """ 
             $($f)(a::CertainValue, b::AbstractUncertainValue; n::Int = 30000)
-        
+
         Compute `a $($operator) b`. Treats the certain value as a scalar and performs the 
         operation element-wise on a default of `n = 30000` realizations of `b`.
 
@@ -19,10 +19,10 @@ for operator in operators
 
         """ 
             $($f)(a::AbstractUncertainValue, b::CertainValue; n::Int = 30000)
-                
+
         Compute `a $($operator) b`. Treats the certain value as a scalar and performs the 
         operation element-wise on a default of `n = 30000` realizations of `a`.
-        
+
         To tune the number of draws to `n`, use the `$($operator)(a, b, n::Int)` syntax.
         """
         function $(f)(a::AbstractUncertainValue, b::CertainValue; n::Int = 30000)
@@ -31,7 +31,7 @@ for operator in operators
 
         """ 
         $($f)(a::AbstractUncertainValue, b::CertainValue; n::Int)
-    
+
         Compute `a $($operator) b`. Treats the certain value as a scalar and performs the 
         operation element-wise on `n` realizations of `a`.
 
@@ -43,10 +43,10 @@ for operator in operators
 
         """ 
             $($f)(a::CertainValue, b::AbstractUncertainValue, n::Int)
-        
+
         Compute `a $($operator) b`. Treats the certain value as a scalar and performs the 
         operation element-wise on `n` realizations of `b`.
-    
+
         This function is called with the `$($operator)(a, b, n::Int)` syntax.
         """
         function $(f)(a::CertainValue, b::AbstractUncertainValue, n::Int)


### PR DESCRIPTION
Found as part of JuliaLang/julia#46372 - the reference parser treats triple quoted lines of uneven whitespace in a weird inconsistent way so this is changed in the new parser. This change removes the uneven whitespace.